### PR TITLE
Revert "Fftw"

### DIFF
--- a/src/Fluxes/Differentiation/SPECTRAL_x.py
+++ b/src/Fluxes/Differentiation/SPECTRAL_x.py
@@ -2,10 +2,33 @@ import numpy as np
 import sys
  
 try:
-    import pyfftw
     from pyfftw.interfaces.scipy_fftpack import fft, ifft, fftfreq, fftn, ifftn
 except:
     from scipy.fftpack import fft, ifft, fftfreq, fftn, ifftn
+
+def ddx_period(f,ik):
+
+    df = np.real(ifft(ik*fft(f,axis=0),axis=0))
+
+    return df
+
+def ddx_even(f,ik):
+
+    N = f.shape[0]
+    fe = np.concatenate([f,f[::-1,:]],axis=0)
+    df = np.real(ifft(ik*fft(fe,axis=0),axis=0))
+    df = df[:N,:]
+    
+    return df
+
+def ddx_odd(f,ik):
+
+    N = f.shape[0]
+    fe = np.concatenate([f,-f[::-1,:]],axis=0)
+    df = np.real(ifft(ik*fft(fe,axis=0),axis=0))
+    df = df[:N,:]
+    
+    return df
 
 def ddx_none(f,ik):
 
@@ -14,96 +37,31 @@ def ddx_none(f,ik):
     return df
 
 def SPECTRAL_x(sim):       # Set the differentiation operators
-
+    
     if sim.Nx == 1:
         sim.ik = 0.
         
         sim.ddx_u = ddx_none
         sim.ddx_v = ddx_none
         sim.ddx_h = ddx_none
-
-    else:
-
-        # If possible, use pyfftw to preserve wisdom.
-        try:
-            tmp_in_u  = pyfftw.n_byte_align_empty((sim.Nkx,sim.Ny),16,dtype='complex128')
-            tmp_out_u = pyfftw.n_byte_align_empty((sim.Nkx,sim.Ny),16,dtype='complex128')
-            sim.fftx_u  = pyfftw.FFTW(tmp_in_u, tmp_out_u, axes=[0], direction='FFTW_FORWARD')
-            sim.ifftx_u = pyfftw.FFTW(tmp_out_u, tmp_in_u, axes=[0], direction='FFTW_BACKWARD')
-
-            tmp_in_v  = pyfftw.n_byte_align_empty((sim.Nkx,sim.Ny),16,dtype='complex128')
-            tmp_out_v = pyfftw.n_byte_align_empty((sim.Nkx,sim.Ny),16,dtype='complex128')
-            sim.fftx_v  = pyfftw.FFTW(tmp_in_v, tmp_out_v, axes=[0], direction='FFTW_FORWARD')
-            sim.ifftx_v = pyfftw.FFTW(tmp_out_v, tmp_in_v, axes=[0], direction='FFTW_BACKWARD')
-
-            tmp_in_h  = pyfftw.n_byte_align_empty((sim.Nkx,sim.Ny),16,dtype='complex128')
-            tmp_out_h = pyfftw.n_byte_align_empty((sim.Nkx,sim.Ny),16,dtype='complex128')
-            sim.fftx_h  = pyfftw.FFTW(tmp_in_h, tmp_out_h, axes=[0], direction='FFTW_FORWARD')
-            sim.ifftx_h = pyfftw.FFTW(tmp_out_h, tmp_in_h, axes=[0], direction='FFTW_BACKWARD')
-
-        except:
-            def ifftx(ar):
-                return ifft(ar,axis=0)
-            def fftx(ar):
-                return fft(ar,axis=0)
-
-            sim.fftx_u  = fftx
-            sim.ifftx_u = ifftx
-            sim.fftx_v  = fftx
-            sim.ifftx_v = ifftx
-            sim.fftx_h  = fftx
-            sim.ifftx_h = ifftx
-            print('Failed to use fftw for x transforms')
-
-        if sim.geomx == 'periodic':
-
-            def ddx_u(f,sim):
-                df = np.real(sim.ifftx_u(sim.ik*sim.fftx_u(f)))
-                return df
-    
-            def ddx_v(f,sim):
-                df = np.real(sim.ifftx_v(sim.ik*sim.fftx_v(f)))
-                return df
-    
-            def ddx_h(f,sim):
-                df = np.real(sim.ifftx_h(sim.ik*sim.fftx_h(f)))
-                return df
-    
-            kx = 2*np.pi/sim.Lx*np.hstack([range(0,int(sim.Nx/2)), range(-int(sim.Nx/2),0)])
-            sim.kx = kx.copy()
-            sim.ik = 1j*np.tile(kx.reshape((sim.Nkx,1)),(1,sim.Ny))
-    
-        elif sim.geomx == 'walls':
-
-            def ddx_u(f,sim):
-                N = f.shape[0]
-                fe = np.concatenate([f,-f[::-1,:]],axis=0)
-                df = np.real(sim.ifftx_u(sim.ik*sim.fftx_u(fe)))[:N,:]
-                return df
-    
-            def ddx_v(f,sim):
-                N = f.shape[0]
-                fe = np.concatenate([f,f[::-1,:]],axis=0)
-                df = np.real(sim.ifftx_v(sim.ik*sim.fftx_v(fe)))[:N,:]
-                return df
-    
-            def ddx_h(f,sim):
-                N = f.shape[0]
-                fe = np.concatenate([f,f[::-1,:]],axis=0)
-                df = np.real(sim.ifftx_h(sim.ik*sim.fftx_h(fe)))[:N,:]
-                return df
-
-            kx = np.pi/sim.Lx*np.hstack([range(0,int(sim.Nx)), range(-int(sim.Nx),0)])
-            sim.kx = kx.copy()
-            sim.ik = 1j*np.tile(kx.reshape((sim.Nkx,1)),(1,sim.Ny))
+    elif sim.geomx == 'periodic':
+        kx = 2*np.pi/sim.Lx*np.hstack([range(0,int(sim.Nx/2)), range(-int(sim.Nx/2),0)])
+        sim.kx = kx.copy()
+        sim.ik = 1j*np.tile(kx.reshape((sim.Nkx,1)),(1,sim.Ny))
         
-        else:
-            print "x boundary conditions must be from the list: periodic, walls"
-            sys.exit()
-
-        sim.ddx_u = ddx_u
-        sim.ddx_v = ddx_v
-        sim.ddx_h = ddx_h
-
+        sim.ddx_u = ddx_period
+        sim.ddx_v = ddx_period
+        sim.ddx_h = ddx_period
+    elif sim.geomx == 'walls':
+        kx = np.pi/sim.Lx*np.hstack([range(0,int(sim.Nx)), range(-int(sim.Nx),0)])
+        sim.kx = kx.copy()
+        sim.ik = 1j*np.tile(kx.reshape((sim.Nkx,1)),(1,sim.Ny))
+        
+        sim.ddx_u = ddx_odd
+        sim.ddx_v = ddx_even
+        sim.ddx_h = ddx_even
+    else:
+        print "y boundary conditions must be from the list: periodic, walls"
+        sys.exit()
 
         

--- a/src/Fluxes/Differentiation/SPECTRAL_y.py
+++ b/src/Fluxes/Differentiation/SPECTRAL_y.py
@@ -1,10 +1,30 @@
 import numpy as np   
 try:
-    import pyfftw
     from pyfftw.interfaces.scipy_fftpack import fft, ifft, fftfreq
 except:
     from scipy.fftpack import fft, ifft, fftfreq
 
+def ddy_period(f,il):
+
+    df = np.real(ifft(il*fft(f,axis=1),axis=1))
+
+    return df
+
+def ddy_even(f,il):
+
+    N = f.shape[1]
+    fe = np.concatenate([f,f[:,::-1]],axis=1)
+    df = np.real(ifft(il*fft(fe,axis=1),axis=1))[:,:N]
+    
+    return df
+
+def ddy_odd(f,il):
+
+    N = f.shape[1]
+    fe = np.concatenate([f,-f[:,::-1]],axis=1)
+    df = np.real(ifft(il*fft(fe,axis=1),axis=1))[:,:N]
+    
+    return df
 
 def ddy_none(f,ik):
 
@@ -12,97 +32,30 @@ def ddy_none(f,ik):
     
     return df
 
-
-def SPECTRAL_y(sim):       # Set the differentiation operators
-
+def SPECTRAL_y(sim):  # Set the differentiation operators
+    
     if sim.Ny == 1:
-        sim.il = 0.
+        sim.il = 0
         
         sim.ddy_u = ddy_none
         sim.ddy_v = ddy_none
         sim.ddy_h = ddy_none
-
-    else:
-
-        # If possible, use pyfftw to preserve wisdom.
-        try:
-            tmp_in_u  = pyfftw.n_byte_align_empty((sim.Nx,sim.Nky),16,dtype='complex128')
-            tmp_out_u = pyfftw.n_byte_align_empty((sim.Nx,sim.Nky),16,dtype='complex128')
-            sim.ffty_u  = pyfftw.FFTW(tmp_in_u, tmp_out_u, axes=[1], direction='FFTW_FORWARD')
-            sim.iffty_u = pyfftw.FFTW(tmp_out_u, tmp_in_u, axes=[1], direction='FFTW_BACKWARD')
-
-            tmp_in_v  = pyfftw.n_byte_align_empty((sim.Nx,sim.Nky),16,dtype='complex128')
-            tmp_out_v = pyfftw.n_byte_align_empty((sim.Nx,sim.Nky),16,dtype='complex128')
-            sim.ffty_v  = pyfftw.FFTW(tmp_in_v, tmp_out_v, axes=[1], direction='FFTW_FORWARD')
-            sim.iffty_v = pyfftw.FFTW(tmp_out_v, tmp_in_v, axes=[1], direction='FFTW_BACKWARD')
-
-            tmp_in_h  = pyfftw.n_byte_align_empty((sim.Nx,sim.Nky),16,dtype='complex128')
-            tmp_out_h = pyfftw.n_byte_align_empty((sim.Nx,sim.Nky),16,dtype='complex128')
-            sim.ffty_h  = pyfftw.FFTW(tmp_in_h, tmp_out_h, axes=[1], direction='FFTW_FORWARD')
-            sim.iffty_h = pyfftw.FFTW(tmp_out_h, tmp_in_h, axes=[1], direction='FFTW_BACKWARD')
-
-        except:
-            def iffty(ar):
-                return ifft(ar,axis=1)
-            def ffty(ar):
-                return fft(ar,axis=1)
-
-            sim.ffty_u  = ffty
-            sim.iffty_u = iffty
-            sim.ffty_v  = ffty
-            sim.iffty_v = iffty
-            sim.ffty_h  = ffty
-            sim.iffty_h = iffty
-            print('Failed to use fftw for y transforms')
-
-        if sim.geomy == 'periodic':
-
-            def ddy_u(f,sim):
-                df = np.real(sim.iffty_u(sim.il*sim.ffty_u(f)))
-                return df
-    
-            def ddy_v(f,sim):
-                df = np.real(sim.iffty_v(sim.il*sim.ffty_v(f)))
-                return df
-    
-            def ddy_h(f,sim):
-                df = np.real(sim.iffty_h(sim.il*sim.ffty_h(f)))
-                return df
-
-            ky = 2*np.pi/sim.Ly*np.hstack([range(0,int(sim.Ny/2)), range(-int(sim.Ny/2),0)])
-            sim.ky = ky.copy()
-            sim.il = 1j*np.tile(ky.reshape((1,sim.Nky)),(sim.Nx,1))
-    
-        elif sim.geomy == 'walls':
-
-            def ddy_u(f,sim):
-                N = f.shape[1]
-                fe = np.concatenate([f,f[:,::-1]],axis=0)
-                df = np.real(sim.iffty_u(sim.il*sim.ffty_u(fe)))[:,:N]
-                return df
-    
-            def ddy_v(f,sim):
-                N = f.shape[1]
-                fe = np.concatenate([f,-f[:,::-1]],axis=0)
-                df = np.real(sim.iffty_v(sim.il*sim.ffty_v(fe)))[:,:N]
-                return df
-    
-            def ddy_h(f,sim):
-                N = f.shape[1]
-                fe = np.concatenate([f,f[:,::-1]],axis=0)
-                df = np.real(sim.iffty_h(sim.il*sim.ffty_h(fe)))[:,:N]
-                return df
-
-            ky = np.pi/sim.Ly*np.hstack([range(0,int(sim.Ny)), range(-int(sim.Ny),0)])
-            sim.ky = ky.copy()
-            sim.il = 1j*np.tile(ky.reshape((1,sim.Nky)),(sim.Nx,1))
+    elif sim.geomy == 'periodic':
+        ky = 2*np.pi/sim.Ly*np.hstack([range(0,int(sim.Ny/2)), range(-int(sim.Ny/2),0)])
+        sim.ky = ky.copy()
+        sim.il = 1j*np.tile(ky.reshape((1,sim.Nky)),(sim.Nx,1))
         
-        else:
-            print "y boundary conditions must be from the list: periodic, walls"
-            sys.exit()
-
-        sim.ddy_u = ddy_u
-        sim.ddy_v = ddy_v
-        sim.ddy_h = ddy_h
-
-
+        sim.ddy_u = ddy_period
+        sim.ddy_v = ddy_period
+        sim.ddy_h = ddy_period
+    elif sim.geomy == 'walls':
+        ky = np.pi/sim.Ly*np.hstack([range(0,int(sim.Ny)), range(-int(sim.Ny),0)])
+        sim.ky = ky.copy()
+        sim.il = 1j*np.tile(ky.reshape((1,sim.Nky)),(sim.Nx,1))
+        
+        sim.ddy_u = ddy_even
+        sim.ddy_v = ddy_odd
+        sim.ddy_h = ddy_even
+    else:
+        print "y boundary conditions must be from the list: periodic, walls"
+        sys.exit()

--- a/src/Fluxes/SPECTRAL_SW.py
+++ b/src/Fluxes/SPECTRAL_SW.py
@@ -4,7 +4,6 @@ import matplotlib.pyplot as plt
 import sys
 
 try:
-    import pyfftw
     from pyfftw.interfaces.scipy_fftpack import fft, ifft, fftfreq, fftn, ifftn
 except:
     from scipy.fftpack import fft, ifft, fftfreq, fftn, ifftn
@@ -19,7 +18,7 @@ def spectral_sw_flux(sim):
         v = sim.soln.v[:,:,ii].reshape((sim.Nx,sim.Ny))
 
         # Compute x-derivatives
-        du, dv, dh = sim.ddx_u(u,sim), sim.ddx_v(v,sim), sim.ddx_h(h,sim)
+        du, dv, dh = sim.ddx_u(u,sim.ik), sim.ddx_v(v,sim.ik), sim.ddx_h(h,sim.ik)
 
         # Coriolis and x-derivatives
         sim.curr_flux.u[:,:,ii] = - u*du + sim.F*v  - sim.gs[ii]*dh
@@ -27,7 +26,7 @@ def spectral_sw_flux(sim):
         sim.curr_flux.h[:,:,ii] = - u*dh - h*du     
 
         # Compute y-derivatives
-        du, dv, dh = sim.ddy_u(u,sim), sim.ddy_v(v,sim), sim.ddy_h(h,sim)
+        du, dv, dh = sim.ddy_u(u,sim.il), sim.ddy_v(v,sim.il), sim.ddy_h(h,sim.il)
         
         # y-derivatives
         sim.curr_flux.u[:,:,ii] += - v*du
@@ -46,7 +45,7 @@ def spectral_sw_linear_flux(sim):
         v = sim.soln.v[:,:,ii].reshape((sim.Nx,sim.Ny))
 
         # Compute x-derivatives
-        du, dv, dh = sim.ddx_u(u,sim), sim.ddx_v(v,sim), sim.ddx_h(h,sim)
+        du, dv, dh = sim.ddx_u(u,sim.ik), sim.ddx_v(v,sim.ik), sim.ddx_h(h,sim.ik)
 
         # Coriolis and x-derivatives
         sim.curr_flux.u[:,:,ii] =   sim.F*v - sim.gs[ii]*dh
@@ -54,7 +53,7 @@ def spectral_sw_linear_flux(sim):
         sim.curr_flux.h[:,:,ii] = - sim.Hs[ii]*du     
 
         # Compute y-derivatives
-        du, dv, dh = sim.ddy_u(u,sim), sim.ddy_v(v,sim), sim.ddy_h(h,sim)
+        du, dv, dh = sim.ddy_u(u,sim.il), sim.ddy_v(v,sim.il), sim.ddy_h(h,sim.il)
         
         # y-derivatives
         sim.curr_flux.v[:,:,ii] += - sim.gs[ii]*dh
@@ -81,9 +80,9 @@ def filter_general(sim):
             he = np.concatenate([he, he[:,::-1]],axis=1)
 
         # Filter
-        ue = sim.ifftn_u(sim.sfilt*sim.fftn_u(ue)).real
-        ve = sim.ifftn_v(sim.sfilt*sim.fftn_v(ve)).real
-        he = sim.ifftn_h(sim.sfilt*sim.fftn_h(he)).real
+        ue = ifftn(sim.sfilt*fftn(ue,axes=[0,1]),axes=[0,1]).real
+        ve = ifftn(sim.sfilt*fftn(ve,axes=[0,1]),axes=[0,1]).real
+        he = ifftn(sim.sfilt*fftn(he,axes=[0,1]),axes=[0,1]).real
 
         # Project on physical space
         sim.soln.u[:,:,ii] = ue[0:sim.Nx,0:sim.Ny]
@@ -107,38 +106,6 @@ def spectral_sw(sim):
             sim.Nky = sim.Ny
         elif sim.geomy == 'walls':
             sim.Nky = 2*sim.Ny
-
-    # If possible, use pyfftw to preserve wisdom.
-    try:
-        tmp_in_u  = pyfftw.n_byte_align_empty((sim.Nkx,sim.Nky),16,dtype='complex128')
-        tmp_out_u = pyfftw.n_byte_align_empty((sim.Nkx,sim.Nky),16,dtype='complex128')
-        sim.fftn_u  = pyfftw.FFTW(tmp_in_u, tmp_out_u, axes=[0,1], direction='FFTW_FORWARD')
-        sim.ifftn_u = pyfftw.FFTW(tmp_out_u, tmp_in_u, axes=[0,1], direction='FFTW_BACKWARD')
-
-        tmp_in_v  = pyfftw.n_byte_align_empty((sim.Nkx,sim.Nky),16,dtype='complex128')
-        tmp_out_v = pyfftw.n_byte_align_empty((sim.Nkx,sim.Nky),16,dtype='complex128')
-        sim.fftn_v  = pyfftw.FFTW(tmp_in_v, tmp_out_v, axes=[0,1], direction='FFTW_FORWARD')
-        sim.ifftn_v = pyfftw.FFTW(tmp_out_v, tmp_in_v, axes=[0,1], direction='FFTW_BACKWARD')
-
-        tmp_in_h  = pyfftw.n_byte_align_empty((sim.Nkx,sim.Nky),16,dtype='complex128')
-        tmp_out_h = pyfftw.n_byte_align_empty((sim.Nkx,sim.Nky),16,dtype='complex128')
-        sim.fftn_h  = pyfftw.FFTW(tmp_in_h, tmp_out_h, axes=[0,1], direction='FFTW_FORWARD')
-        sim.ifftn_h = pyfftw.FFTW(tmp_out_h, tmp_in_h, axes=[0,1], direction='FFTW_BACKWARD')
-
-    except:
-        def ifftx(ar):
-            return ifftn(ar,axes=[0,1])
-        def fftx(ar):
-            return fftn(ar,axes=[0,1])
-
-        sim.fftn_u  = fftn
-        sim.ifftn_u = ifftn
-        sim.fftn_v  = fftn
-        sim.ifftn_v = ifftn
-        sim.fftn_h  = fftn
-        sim.ifftn_h = ifftn
-        print('Failed to import pyfftw for filter transforms.')
-
         
     sim.x_derivs = Diff.SPECTRAL_x
     sim.y_derivs = Diff.SPECTRAL_y

--- a/src/example_1D_1L_spectral.py
+++ b/src/example_1D_1L_spectral.py
@@ -25,15 +25,15 @@ sim.Ny  = 128             # Grid points in y
 sim.Nz  = 1               # Number of layers
 sim.g   = 9.81            # Gravity                     (m/sec^2)
 sim.f0  = 1.e-4           # Coriolis                    (1/sec)
-sim.cfl = 0.02            # CFL coefficient             (m)
 sim.beta = 1e-10          # Coriolis beta parameter     (1/m/sec)
+sim.cfl = 0.05            # CFL coefficient             (m)
 sim.Hs  = [100.]          # Vector of mean layer depths (m)
 sim.rho = [1025.]         # Vector of layer densities   (kg/m^3)
 sim.end_time = 2*24.*hour   # End Time                    (sec)
 
 # Plotting parameters
 sim.plott   = 20.*minute  # Period of plots
-sim.animate = 'None'      # 'Save' to create video frames,
+sim.animate = 'Anim'      # 'Save' to create video frames,
                           # 'Anim' to animate,
                           # 'None' otherwise
                          
@@ -62,7 +62,6 @@ elif sim.Nx==1:
 
 sim.run()                # Run the simulation
 
-sys.exit()
 
 # Hovmuller plot
 plt.figure()


### PR DESCRIPTION
Reverts PyRsw/PyRsw#6

Problem with the shape of the matrices, see below.

python example_1D_1L_spectral.py 
Parameters:
-----------
geomx    =  walls
stepper  =  <function AB2 at 0x10be270c8>
method   =  Spectral
dynamics =  Nonlinear
Nx       =  1
Ny       =  128
Nz       =  1
Coriolis = beta-plane
 
Traceback (most recent call last):
  File "example_1D_1L_spectral.py", line 63, in <module>
    sim.run()                # Run the simulation
  File "/Users/fpoulin/software/PyRsw/src/PyRsw.py", line 301, in run
    self.step()
  File "/Users/fpoulin/software/PyRsw/src/PyRsw.py", line 231, in step
    self.stepper(self)
  File "/Users/fpoulin/software/PyRsw/src/Steppers/AB2.py", line 11, in AB2
    Euler(sim)
  File "/Users/fpoulin/software/PyRsw/src/Steppers/Euler.py", line 4, in Euler
    sim.flux()
  File "/Users/fpoulin/software/PyRsw/src/PyRsw.py", line 186, in flux
    return self.flux_function(self)
  File "/Users/fpoulin/software/PyRsw/src/Fluxes/SPECTRAL_SW.py", line 30, in spectral_sw_flux
    du, dv, dh = sim.ddy_u(u,sim), sim.ddy_v(v,sim), sim.ddy_h(h,sim)
  File "/Users/fpoulin/software/PyRsw/src/Fluxes/Differentiation/SPECTRAL_y.py", line 81, in ddy_u
    df = np.real(sim.iffty_u(sim.il*sim.ffty_u(fe)))[:,:N]
  File "pyfftw.pyx", line 1277, in pyfftw.pyfftw.FFTW.__call__ (/private/tmp/pip-build-DmI_Hk/pyfftw/pyfftw/pyfftw.c:8346)
ValueError: Invalid input shape: The new input array should be the same shape as the input array used to instantiate the object.
