### PR TITLE
Add Python 3 compatibility

### DIFF
--- a/examples/example_1D_BickleyJet.py
+++ b/examples/example_1D_BickleyJet.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from builtins import range
+from past.utils import old_div
 import numpy as np
 import matplotlib.pyplot as plt
 import sys
@@ -69,11 +72,11 @@ for ii in range(sim.Nz):  # Set mean depths
 # First we define the jet
 Ljet = 10e3            # Jet width
 amp  = 0.1             # Elevation of free-surface in basic state
-sim.soln.h[:,:,0] += -amp*np.tanh(sim.Y/Ljet)
-sim.soln.u[:,:,0]  =  sim.g*amp/(sim.f0*Ljet)/(np.cosh(sim.Y/Ljet)**2)
+sim.soln.h[:,:,0] += -amp*np.tanh(old_div(sim.Y,Ljet))
+sim.soln.u[:,:,0]  =  sim.g*amp/(sim.f0*Ljet)/(np.cosh(old_div(sim.Y,Ljet))**2)
 
 # Then we add on a random perturbation
-sim.soln.u[:,:,0] +=  0e-3*np.exp(-(sim.Y/Ljet)**2)*np.random.randn(sim.Nx,sim.Ny)
+sim.soln.u[:,:,0] +=  0e-3*np.exp(-(old_div(sim.Y,Ljet))**2)*np.random.randn(sim.Nx,sim.Ny)
 
 sim.run()                # Run the simulation
 

--- a/examples/example_1D_BickleyJet.py
+++ b/examples/example_1D_BickleyJet.py
@@ -1,6 +1,5 @@
 from __future__ import division
 from builtins import range
-from past.utils import old_div
 import numpy as np
 import matplotlib.pyplot as plt
 import sys
@@ -50,9 +49,9 @@ sim.animate = 'Save'      # 'Save' to create video frames,
                           # 'Anim' to animate,
                           # 'None' otherwise
 sim.plot_vars = ['h']
-sim.ylims=[[-0.1,0.1]] 
+sim.ylims=[[-0.1,0.1]]
 #sim.plot_vars = ['vort','div']
-#sim.clims = [ [-0.8, 0.8],[-0.1, 0.1]]                         
+#sim.clims = [ [-0.8, 0.8],[-0.1, 0.1]]
 
 # Output parameters
 sim.output = False        # True or False
@@ -72,12 +71,10 @@ for ii in range(sim.Nz):  # Set mean depths
 # First we define the jet
 Ljet = 10e3            # Jet width
 amp  = 0.1             # Elevation of free-surface in basic state
-sim.soln.h[:,:,0] += -amp*np.tanh(old_div(sim.Y,Ljet))
-sim.soln.u[:,:,0]  =  sim.g*amp/(sim.f0*Ljet)/(np.cosh(old_div(sim.Y,Ljet))**2)
+sim.soln.h[:,:,0] += -amp*np.tanh(sim.Y/Ljet)
+sim.soln.u[:,:,0]  =  sim.g*amp/(sim.f0*Ljet)/(np.cosh(sim.Y/Ljet)**2)
 
 # Then we add on a random perturbation
-sim.soln.u[:,:,0] +=  0e-3*np.exp(-(old_div(sim.Y,Ljet))**2)*np.random.randn(sim.Nx,sim.Ny)
+sim.soln.u[:,:,0] +=  0e-3*np.exp(-(sim.Y/Ljet)**2)*np.random.randn(sim.Nx,sim.Ny)
 
 sim.run()                # Run the simulation
-
-

--- a/examples/example_1D_geoadjust.py
+++ b/examples/example_1D_geoadjust.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from builtins import range
+from past.utils import old_div
 import numpy as np
 import matplotlib.pyplot as plt
 import sys
@@ -67,19 +70,19 @@ for ii in range(sim.Nz):  # Set mean depths
 x0 = 1.*sim.Lx/2.      # Centre
 W  = 200.e3                # Width
 amp = 1.                  # Amplitude
-sim.soln.h[:,:,0] += amp*np.exp(-(sim.Y)**2/(W**2))
+sim.soln.h[:,:,0] += amp*np.exp(old_div(-(sim.Y)**2,(W**2)))
 
 sim.run()                # Run the simulation
 
 
 # Hovmuller plot
 plt.figure()
-t = np.arange(0,sim.end_time+sim.plott,sim.plott)/86400.
+t = old_div(np.arange(0,sim.end_time+sim.plott,sim.plott),86400.)
 
 if sim.Ny==1:
-    x = sim.x/1e3
+    x = old_div(sim.x,1e3)
 elif sim.Nx == 1:
-    x = sim.y/1e3
+    x = old_div(sim.y,1e3)
 
 for L in range(sim.Nz):
     field = sim.hov_h[:,0,:].T - np.sum(sim.Hs[L:])

--- a/examples/example_1D_geoadjust.py
+++ b/examples/example_1D_geoadjust.py
@@ -1,6 +1,5 @@
 from __future__ import division
 from builtins import range
-from past.utils import old_div
 import numpy as np
 import matplotlib.pyplot as plt
 import sys
@@ -50,7 +49,7 @@ sim.animate = 'Anim'      # 'Save' to create video frames,
 sim.plot_vars = ['u','v','h']   # Specify which variables to plot
                                 # Specify manual ylimits if desired
                                 # An empty list uses default limits
-sim.ylims=[[-0.18,0.18],[-0.18,0.18],[-0.5,1.0]] 
+sim.ylims=[[-0.18,0.18],[-0.18,0.18],[-0.5,1.0]]
 
 # Output parameters
 sim.output = False        # True or False
@@ -70,19 +69,19 @@ for ii in range(sim.Nz):  # Set mean depths
 x0 = 1.*sim.Lx/2.      # Centre
 W  = 200.e3                # Width
 amp = 1.                  # Amplitude
-sim.soln.h[:,:,0] += amp*np.exp(old_div(-(sim.Y)**2,(W**2)))
+sim.soln.h[:,:,0] += amp*np.exp(-(sim.Y)**2/(W**2))
 
 sim.run()                # Run the simulation
 
 
 # Hovmuller plot
 plt.figure()
-t = old_div(np.arange(0,sim.end_time+sim.plott,sim.plott),86400.)
+t = np.arange(0,sim.end_time+sim.plott,sim.plott)/86400.
 
 if sim.Ny==1:
-    x = old_div(sim.x,1e3)
+    x = sim.x/1e3
 elif sim.Nx == 1:
-    x = old_div(sim.y,1e3)
+    x = sim.y/1e3
 
 for L in range(sim.Nz):
     field = sim.hov_h[:,0,:].T - np.sum(sim.Hs[L:])

--- a/examples/example_1D_geoadjust2.py
+++ b/examples/example_1D_geoadjust2.py
@@ -1,6 +1,5 @@
 from __future__ import division
 from builtins import range
-from past.utils import old_div
 import numpy as np
 import matplotlib.pyplot as plt
 import sys
@@ -51,8 +50,8 @@ sim.plot_vars = ['vort','div','h']   # Specify which variables to plot
 #sim.plot_vars = ['u','v','h']   # Specify which variables to plot
                                 # Specify manual ylimits if desired
                                 # An empty list uses default limits
-sim.ylims=[[-0.01,0.01],[-2.0,2.0],[-1.0,1.0]] 
-#sim.ylims=[[-0.3,0.3],[-0.2,0.2],[-1.0,1.0]] 
+sim.ylims=[[-0.01,0.01],[-2.0,2.0],[-1.0,1.0]]
+#sim.ylims=[[-0.3,0.3],[-0.2,0.2],[-1.0,1.0]]
 
 # Output parameters
 sim.output = False        # True or False
@@ -71,19 +70,19 @@ for ii in range(sim.Nz):  # Set mean depths
 # Hyperbolic Tangent initial conditions
 W  = 50.e3                # Width
 amp = 0.5                  # Amplitude
-sim.soln.h[:,:,0] +=-amp*np.tanh(old_div(sim.Y,W))
+sim.soln.h[:,:,0] +=-amp*np.tanh(sim.Y/W)
 
 sim.run()                # Run the simulation
 
 
 # Hovmuller plot
 plt.figure()
-t = old_div(np.arange(0,sim.end_time+sim.plott,sim.plott),86400.)
+t = np.arange(0,sim.end_time+sim.plott,sim.plott)/86400.
 
 if sim.Ny==1:
-    x = old_div(sim.x,1e3)
+    x = sim.x/1e3
 elif sim.Nx == 1:
-    x = old_div(sim.y,1e3)
+    x = sim.y/1e3
 
 for L in range(sim.Nz):
     field = sim.hov_h[:,0,:].T - np.sum(sim.Hs[L:])

--- a/examples/example_1D_geoadjust2.py
+++ b/examples/example_1D_geoadjust2.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from builtins import range
+from past.utils import old_div
 import numpy as np
 import matplotlib.pyplot as plt
 import sys
@@ -68,19 +71,19 @@ for ii in range(sim.Nz):  # Set mean depths
 # Hyperbolic Tangent initial conditions
 W  = 50.e3                # Width
 amp = 0.5                  # Amplitude
-sim.soln.h[:,:,0] +=-amp*np.tanh(sim.Y/W)
+sim.soln.h[:,:,0] +=-amp*np.tanh(old_div(sim.Y,W))
 
 sim.run()                # Run the simulation
 
 
 # Hovmuller plot
 plt.figure()
-t = np.arange(0,sim.end_time+sim.plott,sim.plott)/86400.
+t = old_div(np.arange(0,sim.end_time+sim.plott,sim.plott),86400.)
 
 if sim.Ny==1:
-    x = sim.x/1e3
+    x = old_div(sim.x,1e3)
 elif sim.Nx == 1:
-    x = sim.y/1e3
+    x = old_div(sim.y,1e3)
 
 for L in range(sim.Nz):
     field = sim.hov_h[:,0,:].T - np.sum(sim.Hs[L:])

--- a/examples/example_1D_sadourny.py
+++ b/examples/example_1D_sadourny.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from builtins import range
+from past.utils import old_div
 import numpy as np
 import matplotlib.pyplot as plt
 import sys
@@ -68,7 +71,7 @@ x0 = 1.*sim.Lx/2.          # Centre
 W  = 200.e3                # Width
 amp = 1.                   # Amplitude
 
-sim.soln.h[:,:,0] += amp*np.exp(-(sim.grid_y.h + sim.Ly/4.)**2/(W**2))
+sim.soln.h[:,:,0] += amp*np.exp(old_div(-(sim.grid_y.h + old_div(sim.Ly,4.))**2,(W**2)))
 #sim.soln.h[:,:,0] += amp*np.exp(-(sim.grid_x.h + sim.Lx/4.)**2/(W**2))
 
 # Run the simulation

--- a/examples/example_1D_sadourny.py
+++ b/examples/example_1D_sadourny.py
@@ -1,6 +1,5 @@
 from __future__ import division
 from builtins import range
-from past.utils import old_div
 import numpy as np
 import matplotlib.pyplot as plt
 import sys
@@ -50,7 +49,7 @@ sim.animate = 'Anim'      # 'Save' to create video frames,
 sim.plot_vars = ['u','v','h']   # Specify which variables to plot
                                 # Specify manual ylimits if desired
                                 # An empty list uses default limits
-sim.ylims=[[-0.18,0.18],[-0.18,0.18],[-0.5,1.0]] 
+sim.ylims=[[-0.18,0.18],[-0.18,0.18],[-0.5,1.0]]
 
 # Output parameters
 sim.output = False        # True or False
@@ -71,11 +70,11 @@ x0 = 1.*sim.Lx/2.          # Centre
 W  = 200.e3                # Width
 amp = 1.                   # Amplitude
 
-sim.soln.h[:,:,0] += amp*np.exp(old_div(-(sim.grid_y.h + old_div(sim.Ly,4.))**2,(W**2)))
+sim.soln.h[:,:,0] += amp*np.exp(-(sim.grid_y.h + sim.Ly/4.)**2/(W**2))
 #sim.soln.h[:,:,0] += amp*np.exp(-(sim.grid_x.h + sim.Lx/4.)**2/(W**2))
 
 # Run the simulation
-sim.run()                
+sim.run()
 
 # Hovmuller plot
 #plt.figure()

--- a/examples/example_2D_BickleyJet.py
+++ b/examples/example_2D_BickleyJet.py
@@ -1,6 +1,5 @@
 from __future__ import division
 from builtins import range
-from past.utils import old_div
 import numpy as np
 import matplotlib.pyplot as plt
 import sys
@@ -49,7 +48,7 @@ sim.animate = 'Save'      # 'Save' to create video frames,
                           # 'Anim' to animate,
                           # 'None' otherwise
 sim.plot_vars = ['vort', 'v', 'u', 'h']
-sim.clims = [ [-0.8, 0.8], [-0.5,0.5], [], []]                         
+sim.clims = [ [-0.8, 0.8], [-0.5,0.5], [], []]
 
 # Output parameters
 sim.output = True        # True or False
@@ -69,13 +68,11 @@ for ii in range(sim.Nz):  # Set mean depths
 # First we define the jet
 Ljet = 10e3            # Jet width
 amp  = 0.1             # Elevation of free-surface in basic state
-sim.soln.h[:,:,0] += -amp*np.tanh(old_div(sim.Y,Ljet))
-sim.soln.u[:,:,0]  =  sim.g*amp/(sim.f0*Ljet)/(np.cosh(old_div(sim.Y,Ljet))**2)
+sim.soln.h[:,:,0] += -amp*np.tanh(sim.Y/Ljet)
+sim.soln.u[:,:,0]  =  sim.g*amp/(sim.f0*Ljet)/(np.cosh(sim.Y/Ljet)**2)
 
 # Then we add on a random perturbation
 np.random.seed(seed=100)
-sim.soln.u[:,:,0] +=  1e-3*np.exp(-(old_div(sim.Y,Ljet))**2)*np.random.randn(sim.Nx,sim.Ny)
+sim.soln.u[:,:,0] +=  1e-3*np.exp(-(sim.Y/Ljet)**2)*np.random.randn(sim.Nx,sim.Ny)
 
 sim.run()                # Run the simulation
-
-

--- a/examples/example_2D_BickleyJet.py
+++ b/examples/example_2D_BickleyJet.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from builtins import range
+from past.utils import old_div
 import numpy as np
 import matplotlib.pyplot as plt
 import sys
@@ -66,12 +69,12 @@ for ii in range(sim.Nz):  # Set mean depths
 # First we define the jet
 Ljet = 10e3            # Jet width
 amp  = 0.1             # Elevation of free-surface in basic state
-sim.soln.h[:,:,0] += -amp*np.tanh(sim.Y/Ljet)
-sim.soln.u[:,:,0]  =  sim.g*amp/(sim.f0*Ljet)/(np.cosh(sim.Y/Ljet)**2)
+sim.soln.h[:,:,0] += -amp*np.tanh(old_div(sim.Y,Ljet))
+sim.soln.u[:,:,0]  =  sim.g*amp/(sim.f0*Ljet)/(np.cosh(old_div(sim.Y,Ljet))**2)
 
 # Then we add on a random perturbation
 np.random.seed(seed=100)
-sim.soln.u[:,:,0] +=  1e-3*np.exp(-(sim.Y/Ljet)**2)*np.random.randn(sim.Nx,sim.Ny)
+sim.soln.u[:,:,0] +=  1e-3*np.exp(-(old_div(sim.Y,Ljet))**2)*np.random.randn(sim.Nx,sim.Ny)
 
 sim.run()                # Run the simulation
 

--- a/examples/example_2D_Bickley_Sadourny.py
+++ b/examples/example_2D_Bickley_Sadourny.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from builtins import range
+from past.utils import old_div
 import numpy as np
 import matplotlib.pyplot as plt
 import sys
@@ -65,13 +68,13 @@ for ii in range(sim.Nz):  # Set mean depths
 # First we define the jet
 Ljet = 10e3            # Jet width
 amp  = 0.1             # Elevation of free-surface in basic state
-sim.soln.h[:,:,0] += - amp*np.tanh((sim.grid_y.h)/Ljet)
-sim.soln.u[:,:,0]  =   sim.g*amp/(sim.f0*Ljet)/(np.cosh((sim.grid_y.u)/Ljet)**2)
+sim.soln.h[:,:,0] += - amp*np.tanh(old_div((sim.grid_y.h),Ljet))
+sim.soln.u[:,:,0]  =   sim.g*amp/(sim.f0*Ljet)/(np.cosh(old_div((sim.grid_y.u),Ljet))**2)
 #sim.soln.h[:,:,0] +=  amp*np.tanh((sim.grid_y.h + sim.Ly/4)/Ljet) - amp*np.tanh((sim.grid_y.h - sim.Ly/4)/Ljet)
 #sim.soln.u[:,:,0]  = -sim.g*amp/(sim.f0*Ljet)/(np.cosh((sim.grid_y.u + sim.Ly/4)/Ljet)**2) + sim.g*amp/(sim.f0*Ljet)/(np.cosh((sim.grid_y.u - sim.Ly/4)/Ljet)**2)
 
 # Then we add on a random perturbation
-sim.soln.u[:,:,0] +=  1e-3*np.exp(-((sim.grid_y.u)/Ljet)**2)*np.random.randn(*sim.grid_y.u.shape)
+sim.soln.u[:,:,0] +=  1e-3*np.exp(-(old_div((sim.grid_y.u),Ljet))**2)*np.random.randn(*sim.grid_y.u.shape)
 #sim.soln.u[:,:,0] +=  1e-3*np.exp(-((sim.grid_y.u-sim.Ly/4)/Ljet)**2)*np.random.randn(*sim.grid_y.u.shape)
 
 sim.run()                # Run the simulation

--- a/examples/example_2D_Bickley_Sadourny.py
+++ b/examples/example_2D_Bickley_Sadourny.py
@@ -1,6 +1,5 @@
 from __future__ import division
 from builtins import range
-from past.utils import old_div
 import numpy as np
 import matplotlib.pyplot as plt
 import sys
@@ -48,7 +47,7 @@ sim.animate = 'Save'      # 'Save' to create video frames,
                           # 'Anim' to animate,
                           # 'None' otherwise
 sim.plot_vars = ['vort', 'v', 'u', 'h']
-sim.clims = [ [-0.8, 0.8], [-0.5,0.5], [], []]                         
+sim.clims = [ [-0.8, 0.8], [-0.5,0.5], [], []]
 
 # Output parameters
 sim.output = True        # True or False
@@ -68,15 +67,13 @@ for ii in range(sim.Nz):  # Set mean depths
 # First we define the jet
 Ljet = 10e3            # Jet width
 amp  = 0.1             # Elevation of free-surface in basic state
-sim.soln.h[:,:,0] += - amp*np.tanh(old_div((sim.grid_y.h),Ljet))
-sim.soln.u[:,:,0]  =   sim.g*amp/(sim.f0*Ljet)/(np.cosh(old_div((sim.grid_y.u),Ljet))**2)
+sim.soln.h[:,:,0] += - amp*np.tanh((sim.grid_y.h)/Ljet)
+sim.soln.u[:,:,0]  =   sim.g*amp/(sim.f0*Ljet)/(np.cosh((sim.grid_y.u)/Ljet)**2)
 #sim.soln.h[:,:,0] +=  amp*np.tanh((sim.grid_y.h + sim.Ly/4)/Ljet) - amp*np.tanh((sim.grid_y.h - sim.Ly/4)/Ljet)
 #sim.soln.u[:,:,0]  = -sim.g*amp/(sim.f0*Ljet)/(np.cosh((sim.grid_y.u + sim.Ly/4)/Ljet)**2) + sim.g*amp/(sim.f0*Ljet)/(np.cosh((sim.grid_y.u - sim.Ly/4)/Ljet)**2)
 
 # Then we add on a random perturbation
-sim.soln.u[:,:,0] +=  1e-3*np.exp(-(old_div((sim.grid_y.u),Ljet))**2)*np.random.randn(*sim.grid_y.u.shape)
+sim.soln.u[:,:,0] +=  1e-3*np.exp(-((sim.grid_y.u)/Ljet)**2)*np.random.randn(*sim.grid_y.u.shape)
 #sim.soln.u[:,:,0] +=  1e-3*np.exp(-((sim.grid_y.u-sim.Ly/4)/Ljet)**2)*np.random.randn(*sim.grid_y.u.shape)
 
 sim.run()                # Run the simulation
-
-

--- a/examples/example_2D_geoadjust.py
+++ b/examples/example_2D_geoadjust.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from builtins import range
+from past.utils import old_div
 import numpy as np
 import matplotlib.pyplot as plt
 import sys
@@ -67,7 +70,7 @@ for ii in range(sim.Nz):  # Set mean depths
 # Gaussian initial conditions
 W  = 200.e3                # Width
 amp = 1.                  # Amplitude
-sim.soln.h[:,:,0] += amp*np.exp(-(sim.X/W)**2 - (sim.Y/W)**2)
+sim.soln.h[:,:,0] += amp*np.exp(-(old_div(sim.X,W))**2 - (old_div(sim.Y,W))**2)
 
 # Run the simulation
 sim.run() 

--- a/examples/example_2D_geoadjust.py
+++ b/examples/example_2D_geoadjust.py
@@ -1,6 +1,5 @@
 from __future__ import division
 from builtins import range
-from past.utils import old_div
 import numpy as np
 import matplotlib.pyplot as plt
 import sys
@@ -52,7 +51,7 @@ sim.animate = 'Anim'      # 'Save' to create video frames,
 sim.plot_vars = ['h']
 #sim.plot_vars = ['vort','div']
 #sim.clims = [[-0.015, 0.015],[-0.001, 0.001]]
-                         
+
 # Output parameters
 sim.output = False        # True or False
 sim.savet  = 1.*hour      # Time between saves
@@ -70,8 +69,7 @@ for ii in range(sim.Nz):  # Set mean depths
 # Gaussian initial conditions
 W  = 200.e3                # Width
 amp = 1.                  # Amplitude
-sim.soln.h[:,:,0] += amp*np.exp(-(old_div(sim.X,W))**2 - (old_div(sim.Y,W))**2)
+sim.soln.h[:,:,0] += amp*np.exp(-(sim.X/W)**2 - (sim.Y/W)**2)
 
 # Run the simulation
-sim.run() 
-
+sim.run()

--- a/examples/example_2D_sadourny.py
+++ b/examples/example_2D_sadourny.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from builtins import range
+from past.utils import old_div
 import numpy as np
 import matplotlib.pyplot as plt
 import sys
@@ -69,19 +72,19 @@ x0 = 1.*sim.Lx/2.          # Centre
 W  = 200.e3                # Width
 amp = 1.                   # Amplitude
 
-sim.soln.h[:,:,0] += amp*np.exp(-(sim.grid_y.h)**2/(W**2))
+sim.soln.h[:,:,0] += amp*np.exp(old_div(-(sim.grid_y.h)**2,(W**2)))
 
 # Run the simulation
 sim.run()                
 
 # Hovmuller plot
 plt.figure()
-t = np.arange(0,sim.end_time+sim.plott,sim.plott)/86400.
+t = old_div(np.arange(0,sim.end_time+sim.plott,sim.plott),86400.)
 
 if sim.Ny==1:
-    x = sim.x/1e3
+    x = old_div(sim.x,1e3)
 elif sim.Nx == 1:
-    x = sim.y/1e3
+    x = old_div(sim.y,1e3)
 
 #for L in range(sim.Nz):
 #    field = sim.hov_h[:,0,:].T - np.sum(sim.Hs[L:])

--- a/examples/example_2D_sadourny.py
+++ b/examples/example_2D_sadourny.py
@@ -1,6 +1,5 @@
 from __future__ import division
 from builtins import range
-from past.utils import old_div
 import numpy as np
 import matplotlib.pyplot as plt
 import sys
@@ -24,7 +23,7 @@ sim.geomy       = 'periodic'       # Geometry Types: 'periodic' or 'walls'
 sim.stepper     = Step.AB3         # Time-stepping algorithm: Euler, AB2, RK4
 sim.dynamics    = 'Linear'      # Dynamics: 'Nonlinear' or 'Linear'
 sim.method      = 'Sadourny'       # Numerical method: 'Sadourny'
-sim.flux_method = Flux.sadourny_sw # Flux method: 
+sim.flux_method = Flux.sadourny_sw # Flux method:
 
 # Specify paramters
 sim.Lx  = 4000e3          # Domain extent               (m)
@@ -51,7 +50,7 @@ sim.animate = 'Anim'      # 'Save' to create video frames,
 sim.plot_vars = ['u','v','h']   # Specify which variables to plot
                                 # Specify manual ylimits if desired
                                 # An empty list uses default limits
-sim.ylims=[[-0.18,0.18],[-0.18,0.18],[-0.5,1.0]] 
+sim.ylims=[[-0.18,0.18],[-0.18,0.18],[-0.5,1.0]]
 
 # Output parameters
 sim.output = False        # True or False
@@ -72,19 +71,19 @@ x0 = 1.*sim.Lx/2.          # Centre
 W  = 200.e3                # Width
 amp = 1.                   # Amplitude
 
-sim.soln.h[:,:,0] += amp*np.exp(old_div(-(sim.grid_y.h)**2,(W**2)))
+sim.soln.h[:,:,0] += amp*np.exp(-(sim.grid_y.h)**2/(W**2))
 
 # Run the simulation
-sim.run()                
+sim.run()
 
 # Hovmuller plot
 plt.figure()
-t = old_div(np.arange(0,sim.end_time+sim.plott,sim.plott),86400.)
+t = np.arange(0,sim.end_time+sim.plott,sim.plott)/86400.
 
 if sim.Ny==1:
-    x = old_div(sim.x,1e3)
+    x = sim.x/1e3
 elif sim.Nx == 1:
-    x = old_div(sim.y,1e3)
+    x = sim.y/1e3
 
 #for L in range(sim.Nz):
 #    field = sim.hov_h[:,0,:].T - np.sum(sim.Hs[L:])

--- a/examples/example_stab_BickleyJet.py
+++ b/examples/example_stab_BickleyJet.py
@@ -1,3 +1,5 @@
+from __future__ import division
+from past.utils import old_div
 import numpy as np
 import matplotlib.pyplot as plt
 import scipy.linalg as spalg
@@ -51,14 +53,14 @@ sim.initialize()
 # Define Differentiation Matrix and grid
 Dy,y = cheb(sim.Ny)
 y   = (y[:,0]+1)*sim.Ly/2
-Dy = Dy*(2/sim.Ly)
+Dy = Dy*(old_div(2,sim.Ly))
 
 # Define Basic State: Bickley Jet
 Ljet = 20e3            # Jet width
 Umax = 0.5             # Maximum speed
 amp  = Umax*sim.f0*Ljet/sim.g    # Elevation of free-surface in basic state
-sim.UB  =  sim.g*amp/(sim.f0*Ljet)/(np.cosh((y-sim.Ly/2.)/Ljet)**2)
-sim.HB  = sim.Hs[0] - amp*np.tanh((y-sim.Ly/2.)/Ljet)
+sim.UB  =  sim.g*amp/(sim.f0*Ljet)/(np.cosh(old_div((y-old_div(sim.Ly,2.)),Ljet))**2)
+sim.HB  = sim.Hs[0] - amp*np.tanh(old_div((y-old_div(sim.Ly,2.)),Ljet))
 sim.dUB = np.dot(Dy,sim.UB) 
 
 # Test Geostrophy
@@ -68,7 +70,7 @@ sim.dUB = np.dot(Dy,sim.UB)
 
 ## Specify wavenumber
 dkk = 2e-2
-kk = np.arange(dkk,2+dkk,dkk)/Ljet
+kk = old_div(np.arange(dkk,2+dkk,dkk),Ljet)
 Nk = len(kk)
 
 ## Storage Arrays

--- a/examples/example_stab_BickleyJet.py
+++ b/examples/example_stab_BickleyJet.py
@@ -1,5 +1,4 @@
 from __future__ import division
-from past.utils import old_div
 import numpy as np
 import matplotlib.pyplot as plt
 import scipy.linalg as spalg
@@ -53,24 +52,24 @@ sim.initialize()
 # Define Differentiation Matrix and grid
 Dy,y = cheb(sim.Ny)
 y   = (y[:,0]+1)*sim.Ly/2
-Dy = Dy*(old_div(2,sim.Ly))
+Dy = Dy*(2/sim.Ly)
 
 # Define Basic State: Bickley Jet
 Ljet = 20e3            # Jet width
 Umax = 0.5             # Maximum speed
 amp  = Umax*sim.f0*Ljet/sim.g    # Elevation of free-surface in basic state
-sim.UB  =  sim.g*amp/(sim.f0*Ljet)/(np.cosh(old_div((y-old_div(sim.Ly,2.)),Ljet))**2)
-sim.HB  = sim.Hs[0] - amp*np.tanh(old_div((y-old_div(sim.Ly,2.)),Ljet))
-sim.dUB = np.dot(Dy,sim.UB) 
+sim.UB  =  sim.g*amp/(sim.f0*Ljet)/(np.cosh((y-sim.Ly/2.)/Ljet)**2)
+sim.HB  = sim.Hs[0] - amp*np.tanh((y-sim.Ly/2.)/Ljet)
+sim.dUB = np.dot(Dy,sim.UB)
 
 # Test Geostrophy
 #if np.amax(sim.f0*sim.UB+sim.g*np.dot(Dy,sim.HB)) > 1e-10:
 #    print "Geostrophic balance not satisfied.  Exit"
-#    sys.exit()    
+#    sys.exit()
 
 ## Specify wavenumber
 dkk = 2e-2
-kk = old_div(np.arange(dkk,2+dkk,dkk),Ljet)
+kk = np.arange(dkk,2+dkk,dkk)/Ljet
 Nk = len(kk)
 
 ## Storage Arrays
@@ -89,6 +88,3 @@ plt.xlabel('k*Ljet')
 plt.title('Growth Rates for Bickley Jet')
 plt.legend(['1st unstable','2nd unstable'])
 plt.show()
-
-
-

--- a/src/Diagnose.py
+++ b/src/Diagnose.py
@@ -1,7 +1,6 @@
 from __future__ import division
 # This file contains the diagnostics code
 from builtins import range
-from past.utils import old_div
 import numpy as np
 import matplotlib.pyplot as plt
 
@@ -14,7 +13,7 @@ def initialize_diagnostics(sim):
     sim.PEs = []
     sim.ENs = []
     sim.Ms  = []
-    sim.next_diag_time = (np.floor(old_div(sim.time,sim.diagt))+1)*sim.diagt
+    sim.next_diag_time = (np.floor(sim.time/sim.diagt)+1)*sim.diagt
 
     # Compute the initial values
     area = sim.dx[0]*sim.dx[1]
@@ -30,8 +29,8 @@ def initialize_diagnostics(sim):
             v   = sim.soln.u[:,:,ii].copy()
             u   = sim.soln.v[:,:,ii].copy()
         else:
-            v   = old_div(sim.soln.u[:,:,ii],(eps + h))
-            u   = old_div(sim.soln.v[:,:,ii],(eps + h))
+            v   = sim.soln.u[:,:,ii]/(eps + h)
+            u   = sim.soln.v[:,:,ii]/(eps + h)
         dH2 = sim.soln.h[:,:,ii]**2 - sim.soln.h[:,:,ii+1]**2
 
         KE += 0.5*sim.rho[ii]*np.sum(np.ravel(area*h*(u**2 + v**2)))
@@ -55,9 +54,9 @@ def compute_KE(sim):
             v   = sim.soln.u[:,:,ii].copy()
             u   = sim.soln.v[:,:,ii].copy()
         else:
-            v   = old_div(sim.soln.u[:,:,ii],(eps + h))
-            u   = old_div(sim.soln.v[:,:,ii],(eps + h))
-        KE += 0.5*sim.rho[ii]*np.sum(np.ravel(area*h*(u**2 + v**2))) 
+            v   = sim.soln.u[:,:,ii]/(eps + h)
+            u   = sim.soln.v[:,:,ii]/(eps + h)
+        KE += 0.5*sim.rho[ii]*np.sum(np.ravel(area*h*(u**2 + v**2)))
     return KE
 
 # Total PE
@@ -79,9 +78,9 @@ def compute_enstrophy(sim):
             v   = sim.soln.u[:,:,ii].copy
             u   = sim.soln.v[:,:,ii].copy()
         else:
-            v   = old_div(sim.soln.u[:,:,ii],(eps + h))
-            u   = old_div(sim.soln.v[:,:,ii],(eps + h))
-        q2  = old_div((sim.dxp(v,sim.dx) - sim.dyp(u,sim.dx) + sim.f0)**2,h)
+            v   = sim.soln.u[:,:,ii]/(eps + h)
+            u   = sim.soln.v[:,:,ii]/(eps + h)
+        q2  = (sim.dxp(v,sim.dx) - sim.dyp(u,sim.dx) + sim.f0)**2/h
         EN += np.sum(np.ravel(q2))
     return EN
 
@@ -92,7 +91,7 @@ def compute_mass(sim):
         h = sim.soln.h[:,:,ii] - sim.soln.h[:,:,ii+1]
         M += Area*np.sum(np.ravel(h))*sim.rho[ii]
     return M
-    
+
 # Update diagnostics
 def update(sim):
 
@@ -108,8 +107,8 @@ def update(sim):
             v   = sim.soln.u[:,:,ii].copy()
             u   = sim.soln.v[:,:,ii].copy()
         else:
-            v   = old_div(sim.soln.u[:,:,ii],(eps + h))
-            u   = old_div(sim.soln.v[:,:,ii],(eps + h))
+            v   = sim.soln.u[:,:,ii]/(eps + h)
+            u   = sim.soln.v[:,:,ii]/(eps + h)
         dH2 = sim.soln.h[:,:,ii]**2 - sim.soln.h[:,:,ii+1]**2
 
         KE += area*0.5*sim.rho[ii]*np.sum(np.ravel(h*(u**2 + v**2)))
@@ -134,7 +133,7 @@ def plot(sim):
     T  = np.array(sim.diag_times)
 
     fig = plt.figure()
-            
+
     plt.subplot(2,2,1)
     plt.plot(T,KE - KE[0])
     plt.title('Tot. KE Dev.')
@@ -148,26 +147,26 @@ def plot(sim):
     plt.locator_params(nbins=5)
 
     plt.subplot(2,2,3)
-    plt.plot(T,old_div((abs(KE) + abs(PE)),(KE[0]+PE[0])) - 1)
+    plt.plot(T,(abs(KE) + abs(PE))/(KE[0]+PE[0]) - 1)
     plt.title('Rel. Energy Dev.')
     plt.tight_layout()
     plt.locator_params(nbins=5)
 
     plt.subplot(2,2,4)
-    plt.plot(T,old_div(M,M[0]) - 1.0)
+    plt.plot(T,M/M[0] - 1.0)
     plt.title('Rel. Mass Dev.')
     plt.tight_layout()
     plt.locator_params(nbins=5)
 
     fig.tight_layout()
     fig.savefig('Outputs/{0:s}/diagnostics.pdf'.format(sim.run_name))
-    
+
     return fig
 
 def save(sim):
     if sim.output:
         fname = 'Outputs/{0:s}/diagnostics'.format(sim.run_name)
-        np.savez_compressed(fname, KE = np.array(sim.KEs), 
+        np.savez_compressed(fname, KE = np.array(sim.KEs),
                                    PE = np.array(sim.PEs),
                                    EN = np.array(sim.ENs),
                                    M  = np.array(sim.Ms))

--- a/src/Diagnose.py
+++ b/src/Diagnose.py
@@ -1,4 +1,7 @@
+from __future__ import division
 # This file contains the diagnostics code
+from builtins import range
+from past.utils import old_div
 import numpy as np
 import matplotlib.pyplot as plt
 
@@ -11,7 +14,7 @@ def initialize_diagnostics(sim):
     sim.PEs = []
     sim.ENs = []
     sim.Ms  = []
-    sim.next_diag_time = (np.floor(sim.time/sim.diagt)+1)*sim.diagt
+    sim.next_diag_time = (np.floor(old_div(sim.time,sim.diagt))+1)*sim.diagt
 
     # Compute the initial values
     area = sim.dx[0]*sim.dx[1]
@@ -27,8 +30,8 @@ def initialize_diagnostics(sim):
             v   = sim.soln.u[:,:,ii].copy()
             u   = sim.soln.v[:,:,ii].copy()
         else:
-            v   = sim.soln.u[:,:,ii]/(eps + h)
-            u   = sim.soln.v[:,:,ii]/(eps + h)
+            v   = old_div(sim.soln.u[:,:,ii],(eps + h))
+            u   = old_div(sim.soln.v[:,:,ii],(eps + h))
         dH2 = sim.soln.h[:,:,ii]**2 - sim.soln.h[:,:,ii+1]**2
 
         KE += 0.5*sim.rho[ii]*np.sum(np.ravel(area*h*(u**2 + v**2)))
@@ -52,8 +55,8 @@ def compute_KE(sim):
             v   = sim.soln.u[:,:,ii].copy()
             u   = sim.soln.v[:,:,ii].copy()
         else:
-            v   = sim.soln.u[:,:,ii]/(eps + h)
-            u   = sim.soln.v[:,:,ii]/(eps + h)
+            v   = old_div(sim.soln.u[:,:,ii],(eps + h))
+            u   = old_div(sim.soln.v[:,:,ii],(eps + h))
         KE += 0.5*sim.rho[ii]*np.sum(np.ravel(area*h*(u**2 + v**2))) 
     return KE
 
@@ -76,9 +79,9 @@ def compute_enstrophy(sim):
             v   = sim.soln.u[:,:,ii].copy
             u   = sim.soln.v[:,:,ii].copy()
         else:
-            v   = sim.soln.u[:,:,ii]/(eps + h)
-            u   = sim.soln.v[:,:,ii]/(eps + h)
-        q2  = (sim.dxp(v,sim.dx) - sim.dyp(u,sim.dx) + sim.f0)**2/h
+            v   = old_div(sim.soln.u[:,:,ii],(eps + h))
+            u   = old_div(sim.soln.v[:,:,ii],(eps + h))
+        q2  = old_div((sim.dxp(v,sim.dx) - sim.dyp(u,sim.dx) + sim.f0)**2,h)
         EN += np.sum(np.ravel(q2))
     return EN
 
@@ -105,8 +108,8 @@ def update(sim):
             v   = sim.soln.u[:,:,ii].copy()
             u   = sim.soln.v[:,:,ii].copy()
         else:
-            v   = sim.soln.u[:,:,ii]/(eps + h)
-            u   = sim.soln.v[:,:,ii]/(eps + h)
+            v   = old_div(sim.soln.u[:,:,ii],(eps + h))
+            u   = old_div(sim.soln.v[:,:,ii],(eps + h))
         dH2 = sim.soln.h[:,:,ii]**2 - sim.soln.h[:,:,ii+1]**2
 
         KE += area*0.5*sim.rho[ii]*np.sum(np.ravel(h*(u**2 + v**2)))
@@ -145,13 +148,13 @@ def plot(sim):
     plt.locator_params(nbins=5)
 
     plt.subplot(2,2,3)
-    plt.plot(T,(abs(KE) + abs(PE))/(KE[0]+PE[0]) - 1)
+    plt.plot(T,old_div((abs(KE) + abs(PE)),(KE[0]+PE[0])) - 1)
     plt.title('Rel. Energy Dev.')
     plt.tight_layout()
     plt.locator_params(nbins=5)
 
     plt.subplot(2,2,4)
-    plt.plot(T,M/M[0] - 1.0)
+    plt.plot(T,old_div(M,M[0]) - 1.0)
     plt.title('Rel. Mass Dev.')
     plt.tight_layout()
     plt.locator_params(nbins=5)

--- a/src/Fluxes/Differentiation/SADOURNY_x.py
+++ b/src/Fluxes/Differentiation/SADOURNY_x.py
@@ -1,4 +1,6 @@
 from __future__ import print_function
+from __future__ import division
+from past.utils import old_div
 import numpy as np
 import sys
  
@@ -7,21 +9,21 @@ def ddx_none(f,dx):
 
 def ddx(f,dx):
 
-    df = (f[1:,:] - f[0:-1,:])/dx
+    df = old_div((f[1:,:] - f[0:-1,:]),dx)
             
     return df
 
 def ddx_periodic(f,dx):
 
     fs = np.concatenate([f[-1:,:],f,f[0:1,:]],axis=0)
-    df = (fs[1:,:] - fs[0:-1,:])/dx
+    df = old_div((fs[1:,:] - fs[0:-1,:]),dx)
             
     return df
 
 def ddx_walls(f,dx):
 
     fs = np.concatenate([-f[0:1,:],f,-f[-1:,:]],axis=0)
-    df = (fs[1:,:] - fs[0:-1,:])/dx
+    df = old_div((fs[1:,:] - fs[0:-1,:]),dx)
             
     return df
 

--- a/src/Fluxes/Differentiation/SADOURNY_x.py
+++ b/src/Fluxes/Differentiation/SADOURNY_x.py
@@ -1,30 +1,29 @@
 from __future__ import print_function
 from __future__ import division
-from past.utils import old_div
 import numpy as np
 import sys
- 
+
 def ddx_none(f,dx):
     return 0.
 
 def ddx(f,dx):
 
-    df = old_div((f[1:,:] - f[0:-1,:]),dx)
-            
+    df = (f[1:,:] - f[0:-1,:])/dx
+
     return df
 
 def ddx_periodic(f,dx):
 
     fs = np.concatenate([f[-1:,:],f,f[0:1,:]],axis=0)
-    df = old_div((fs[1:,:] - fs[0:-1,:]),dx)
-            
+    df = (fs[1:,:] - fs[0:-1,:])/dx
+
     return df
 
 def ddx_walls(f,dx):
 
     fs = np.concatenate([-f[0:1,:],f,-f[-1:,:]],axis=0)
-    df = old_div((fs[1:,:] - fs[0:-1,:]),dx)
-            
+    df = (fs[1:,:] - fs[0:-1,:])/dx
+
     return df
 
 def avx_none(f):
@@ -34,27 +33,27 @@ def avx_none(f):
 def avx(f):
 
     af = 0.5*(f[1:,:] + f[0:-1,:])
-            
+
     return af
 
 def avx_periodic(f):
 
     fs = np.concatenate([f[-1:,:],f,f[0:1,:]],axis=0)
     af = 0.5*(fs[1:,:] + fs[0:-1,:])
-            
+
     return af
 
 def avx_walls(f):
 
     fs = np.concatenate([-f[0:1,:],f,-f[-1:,:]],axis=0)
     af = 0.5*(fs[1:,:] + fs[0:-1,:])
-            
+
     return af
 
 def SADOURNY_x(sim):       # Set the differentiation operators
 
     if sim.Nx == 1:
-        
+
         sim.ddx_u = ddx_none
         sim.ddx_v = ddx_none
         sim.ddx_h = ddx_none
@@ -73,7 +72,7 @@ def SADOURNY_x(sim):       # Set the differentiation operators
             sim.avx_h = fort.avx
 
             if sim.geomx == 'periodic':
-            
+
                 sim.ddx_u = fort.ddx_periodic
                 sim.avx_u = fort.avx_periodic
 
@@ -96,7 +95,7 @@ def SADOURNY_x(sim):       # Set the differentiation operators
             sim.avx_h = avx
 
             if sim.geomx == 'periodic':
-            
+
                 sim.ddx_u = ddx_periodic
                 sim.avx_u = avx_periodic
 

--- a/src/Fluxes/Differentiation/SADOURNY_x.py
+++ b/src/Fluxes/Differentiation/SADOURNY_x.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import numpy as np
 import sys
  
@@ -80,7 +81,7 @@ def SADOURNY_x(sim):       # Set the differentiation operators
                 sim.avx_u = fort.avx_walls
 
             else:
-                print "x boundary conditions must be from the list: periodic, walls"
+                print("x boundary conditions must be from the list: periodic, walls")
                 sys.exit()
 
             print('Using Fortran in x')
@@ -103,5 +104,5 @@ def SADOURNY_x(sim):       # Set the differentiation operators
                 sim.avx_u = avx_walls
 
             else:
-                print "x boundary conditions must be from the list: periodic, walls"
+                print("x boundary conditions must be from the list: periodic, walls")
                 sys.exit()

--- a/src/Fluxes/Differentiation/SADOURNY_y.py
+++ b/src/Fluxes/Differentiation/SADOURNY_y.py
@@ -1,65 +1,64 @@
 from __future__ import print_function
 from __future__ import division
-from past.utils import old_div
 import numpy as np
 import sys
- 
+
 def ddy_none(f,dy):
 
     df = 0.0
-    
+
     return df
 
 def ddy(f,dy):
 
-    df = old_div((f[:,1:] - f[:,0:-1]),dy)
-            
+    df = (f[:,1:] - f[:,0:-1])/dy
+
     return df
 
 def ddy_periodic(f,dy):
 
     fs = np.concatenate([f[:,-1:],f,f[:,0:1]],axis=1)
-    df = old_div((fs[:,1:] - fs[:,0:-1]),dy)
-            
+    df = (fs[:,1:] - fs[:,0:-1])/dy
+
     return df
 
 def ddy_walls(f,dy):
 
     fs = np.concatenate([-f[:,0:1],f,-f[:,-1:]],axis=1)
-    df = old_div((fs[:,1:] - fs[:,0:-1]),dy)
-            
+    df = (fs[:,1:] - fs[:,0:-1])/dy
+
     return df
 
 def avy_none(f):
 
     af = f
-            
+
     return af
 
 def avy(f):
 
     af = 0.5*(f[:,1:] + f[:,0:-1])
-            
+
     return af
 
 def avy_periodic(f):
 
     fs = np.concatenate([f[:,-1:],f,f[:,0:1]],axis=1)
     af = 0.5*(fs[:,1:] + fs[:,0:-1])
-            
+
     return af
 
 def avy_walls(f):
 
     fs = np.concatenate([-f[:,0:1],f,-f[:,-1:]],axis=1)
     af = 0.5*(fs[:,1:] + fs[:,0:-1])
-    
+
     return af
 
 def SADOURNY_y(sim):       # Set the differentiation operators
 
     if sim.Ny == 1:
-        
+
         sim.ddy_u = ddy_none
         sim.ddy_v = ddy_none
         sim.ddy_h = ddy_none
@@ -78,12 +77,12 @@ def SADOURNY_y(sim):       # Set the differentiation operators
             sim.avy_h = fort.avy
 
             if sim.geomy == 'periodic':
-            
+
                 sim.ddy_v = fort.ddy_periodic
                 sim.avy_v = fort.avy_periodic
-            
+
             elif sim.geomy == 'walls':
-            
+
                 sim.ddy_v = fort.ddy_walls
                 sim.avy_v = fort.avy_walls
 
@@ -102,18 +101,15 @@ def SADOURNY_y(sim):       # Set the differentiation operators
             sim.avy_h = avy
 
             if sim.geomy == 'periodic':
-            
+
                 sim.ddy_v = ddy_periodic
                 sim.avy_v = avy_periodic
-            
+
             elif sim.geomy == 'walls':
-            
+
                 sim.ddy_v = ddy_walls
                 sim.avy_v = avy_walls
 
             else:
                 print("y boundary conditions must be from the list: periodic, walls")
                 sys.exit()
-
-
-            

--- a/src/Fluxes/Differentiation/SADOURNY_y.py
+++ b/src/Fluxes/Differentiation/SADOURNY_y.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import numpy as np
 import sys
  
@@ -85,7 +86,7 @@ def SADOURNY_y(sim):       # Set the differentiation operators
                 sim.avy_v = fort.avy_walls
 
             else:
-                print "y boundary conditions must be from the list: periodic, walls"
+                print("y boundary conditions must be from the list: periodic, walls")
                 sys.exit()
 
 
@@ -109,7 +110,7 @@ def SADOURNY_y(sim):       # Set the differentiation operators
                 sim.avy_v = avy_walls
 
             else:
-                print "y boundary conditions must be from the list: periodic, walls"
+                print("y boundary conditions must be from the list: periodic, walls")
                 sys.exit()
 
 

--- a/src/Fluxes/Differentiation/SADOURNY_y.py
+++ b/src/Fluxes/Differentiation/SADOURNY_y.py
@@ -1,4 +1,6 @@
 from __future__ import print_function
+from __future__ import division
+from past.utils import old_div
 import numpy as np
 import sys
  
@@ -10,21 +12,21 @@ def ddy_none(f,dy):
 
 def ddy(f,dy):
 
-    df = (f[:,1:] - f[:,0:-1])/dy
+    df = old_div((f[:,1:] - f[:,0:-1]),dy)
             
     return df
 
 def ddy_periodic(f,dy):
 
     fs = np.concatenate([f[:,-1:],f,f[:,0:1]],axis=1)
-    df = (fs[:,1:] - fs[:,0:-1])/dy
+    df = old_div((fs[:,1:] - fs[:,0:-1]),dy)
             
     return df
 
 def ddy_walls(f,dy):
 
     fs = np.concatenate([-f[:,0:1],f,-f[:,-1:]],axis=1)
-    df = (fs[:,1:] - fs[:,0:-1])/dy
+    df = old_div((fs[:,1:] - fs[:,0:-1]),dy)
             
     return df
 

--- a/src/Fluxes/Differentiation/SPECTRAL_x.py
+++ b/src/Fluxes/Differentiation/SPECTRAL_x.py
@@ -1,4 +1,7 @@
 from __future__ import print_function
+from __future__ import division
+from builtins import range
+from past.utils import old_div
 import numpy as np
 import sys
  
@@ -71,7 +74,7 @@ def SPECTRAL_x(sim):       # Set the differentiation operators
                 df = np.real(sim.ifftx_h(sim.ik*sim.fftx_h(f)))
                 return df
     
-            kx = 2*np.pi/sim.Lx*np.hstack([range(0,int(sim.Nx/2)), range(-int(sim.Nx/2),0)])
+            kx = 2*np.pi/sim.Lx*np.hstack([list(range(0,int(old_div(sim.Nx,2)))), list(range(-int(old_div(sim.Nx,2)),0))])
             sim.kx = kx.copy()
             sim.ik = 1j*np.tile(kx.reshape((sim.Nkx,1)),(1,sim.Ny))
     
@@ -95,7 +98,7 @@ def SPECTRAL_x(sim):       # Set the differentiation operators
                 df = np.real(sim.ifftx_h(sim.ik*sim.fftx_h(fe)))[:N,:]
                 return df
 
-            kx = np.pi/sim.Lx*np.hstack([range(0,int(sim.Nx)), range(-int(sim.Nx),0)])
+            kx = np.pi/sim.Lx*np.hstack([list(range(0,int(sim.Nx))), list(range(-int(sim.Nx),0))])
             sim.kx = kx.copy()
             sim.ik = 1j*np.tile(kx.reshape((sim.Nkx,1)),(1,sim.Ny))
         

--- a/src/Fluxes/Differentiation/SPECTRAL_x.py
+++ b/src/Fluxes/Differentiation/SPECTRAL_x.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import numpy as np
 import sys
  
@@ -99,7 +100,7 @@ def SPECTRAL_x(sim):       # Set the differentiation operators
             sim.ik = 1j*np.tile(kx.reshape((sim.Nkx,1)),(1,sim.Ny))
         
         else:
-            print "x boundary conditions must be from the list: periodic, walls"
+            print("x boundary conditions must be from the list: periodic, walls")
             sys.exit()
 
         sim.ddx_u = ddx_u

--- a/src/Fluxes/Differentiation/SPECTRAL_y.py
+++ b/src/Fluxes/Differentiation/SPECTRAL_y.py
@@ -1,4 +1,7 @@
 from __future__ import print_function
+from __future__ import division
+from builtins import range
+from past.utils import old_div
 import numpy as np   
 try:
     import pyfftw
@@ -71,7 +74,7 @@ def SPECTRAL_y(sim):       # Set the differentiation operators
                 df = np.real(sim.iffty_h(sim.il*sim.ffty_h(f)))
                 return df
 
-            ky = 2*np.pi/sim.Ly*np.hstack([range(0,int(sim.Ny/2)), range(-int(sim.Ny/2),0)])
+            ky = 2*np.pi/sim.Ly*np.hstack([list(range(0,int(old_div(sim.Ny,2)))), list(range(-int(old_div(sim.Ny,2)),0))])
             sim.ky = ky.copy()
             sim.il = 1j*np.tile(ky.reshape((1,sim.Nky)),(sim.Nx,1))
     
@@ -95,7 +98,7 @@ def SPECTRAL_y(sim):       # Set the differentiation operators
                 df = np.real(sim.iffty_h(sim.il*sim.ffty_h(fe)))[:,:N]
                 return df
 
-            ky = np.pi/sim.Ly*np.hstack([range(0,int(sim.Ny)), range(-int(sim.Ny),0)])
+            ky = np.pi/sim.Ly*np.hstack([list(range(0,int(sim.Ny))), list(range(-int(sim.Ny),0))])
             sim.ky = ky.copy()
             sim.il = 1j*np.tile(ky.reshape((1,sim.Nky)),(sim.Nx,1))
         

--- a/src/Fluxes/Differentiation/SPECTRAL_y.py
+++ b/src/Fluxes/Differentiation/SPECTRAL_y.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import numpy as np   
 try:
     import pyfftw
@@ -99,7 +100,7 @@ def SPECTRAL_y(sim):       # Set the differentiation operators
             sim.il = 1j*np.tile(ky.reshape((1,sim.Nky)),(sim.Nx,1))
         
         else:
-            print "y boundary conditions must be from the list: periodic, walls"
+            print("y boundary conditions must be from the list: periodic, walls")
             sys.exit()
 
         sim.ddy_u = ddy_u

--- a/src/Fluxes/Differentiation/__init__.py
+++ b/src/Fluxes/Differentiation/__init__.py
@@ -1,11 +1,12 @@
+from __future__ import absolute_import
 # Differentiation
 #     This module provides the differentiation
 #     functions for the simulator class.
 
 # Import the interpolator options
-from SPECTRAL_x import SPECTRAL_x
-from SPECTRAL_y import SPECTRAL_y
+from .SPECTRAL_x import SPECTRAL_x
+from .SPECTRAL_y import SPECTRAL_y
 
 # FJP: if statement
-from SADOURNY_x import SADOURNY_x
-from SADOURNY_y import SADOURNY_y
+from .SADOURNY_x import SADOURNY_x
+from .SADOURNY_y import SADOURNY_y

--- a/src/Fluxes/SADOURNY_SW.py
+++ b/src/Fluxes/SADOURNY_SW.py
@@ -2,7 +2,6 @@ from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
 from builtins import range
-from past.utils import old_div
 from . import Differentiation as Diff
 import numpy as np
 import sys
@@ -24,7 +23,7 @@ import sys
 #      |           |          |         |
 #      |           |          |         |
 #      h --  u --  h  -- u -- h -- u -- h --
-#      |           |          |         | 
+#      |           |          |         |
 #      |           |          |         |
 #      v     q     v     q    v    q    v
 #      |           |          |         |
@@ -36,7 +35,7 @@ import sys
 # If Periodic X Walls:  u,h: Nx by (Ny+1) and
 #                         v: Nx by Ny
 # If Walls X Periodic:  v,h: (Nx+1) by Ny and
-#                         u: Nx by Ny      
+#                         u: Nx by Ny
 #
 # N,S rows:
 # -> must advance u,h
@@ -56,7 +55,7 @@ def sadourny_sw_flux(sim):
 
     Nx, Ny, Nz = sim.Nx, sim.Ny, sim.Nz
     dx, dy     = sim.dx[0], sim.dx[1]
-    
+
     # Loop through each layer and compute the flux
     for ii in range(Nz):
 
@@ -66,10 +65,10 @@ def sadourny_sw_flux(sim):
         v = sim.soln.v[:,:,ii]
 
         # Compute secondary varibles
-        U = sim.avx_h(h)*u                  
+        U = sim.avx_h(h)*u
         V = sim.avy_h(h)*v
         B = sim.gs[ii]*h + 0.5*(sim.avx_u(u**2) + sim.avy_v(v**2))
-        q = old_div((sim.ddx_v(v,dx) - sim.ddy_u(u,dy)  + sim.F),(sim.avy_u(sim.avx_h(h))))  
+        q = (sim.ddx_v(v,dx) - sim.ddy_u(u,dy)  + sim.F)/(sim.avy_u(sim.avx_h(h)))
 
         # Flux
         #sim.curr_flux.u[:,:,ii] =   sim.avy_v(q*sim.avx_v(V)) - sim.ddx_h(B,dx)
@@ -86,7 +85,7 @@ def sadourny_sw_linear_flux(sim):
     #ddx, ddy   = sim.ddx, sim.ddy
     #avx, avy   = sim.avx, sim.avy
     Hs         = sim.Hs[0]
-    
+
     # Loop through each layer and compute the flux
     for ii in range(sim.Nz):
 
@@ -96,9 +95,9 @@ def sadourny_sw_linear_flux(sim):
         v = sim.soln.v[:,:,ii]
 
         # Compute secondary varibles
-        U = Hs*u             
+        U = Hs*u
         V = Hs*v
-        q = old_div(sim.F,Hs)
+        q = sim.F/Hs
         B = sim.gs[ii]*h
 
         # Flux
@@ -120,7 +119,7 @@ def sadourny_sw(sim):
             sim.Nkx = sim.Nx
         elif sim.geomx == 'walls':
             sim.Nkx = 2*sim.Nx
-            
+
     if sim.Ny == 1:
         sim.Nky = 1
     else:
@@ -139,4 +138,3 @@ def sadourny_sw(sim):
     else:
         print("dynamics must be from the list: Nonlinear, Linear")
         sys.exit()
-            

--- a/src/Fluxes/SADOURNY_SW.py
+++ b/src/Fluxes/SADOURNY_SW.py
@@ -1,5 +1,8 @@
 from __future__ import print_function
 from __future__ import absolute_import
+from __future__ import division
+from builtins import range
+from past.utils import old_div
 from . import Differentiation as Diff
 import numpy as np
 import sys
@@ -66,7 +69,7 @@ def sadourny_sw_flux(sim):
         U = sim.avx_h(h)*u                  
         V = sim.avy_h(h)*v
         B = sim.gs[ii]*h + 0.5*(sim.avx_u(u**2) + sim.avy_v(v**2))
-        q = (sim.ddx_v(v,dx) - sim.ddy_u(u,dy)  + sim.F)/(sim.avy_u(sim.avx_h(h)))  
+        q = old_div((sim.ddx_v(v,dx) - sim.ddy_u(u,dy)  + sim.F),(sim.avy_u(sim.avx_h(h))))  
 
         # Flux
         #sim.curr_flux.u[:,:,ii] =   sim.avy_v(q*sim.avx_v(V)) - sim.ddx_h(B,dx)
@@ -95,7 +98,7 @@ def sadourny_sw_linear_flux(sim):
         # Compute secondary varibles
         U = Hs*u             
         V = Hs*v
-        q = sim.F/Hs
+        q = old_div(sim.F,Hs)
         B = sim.gs[ii]*h
 
         # Flux

--- a/src/Fluxes/SADOURNY_SW.py
+++ b/src/Fluxes/SADOURNY_SW.py
@@ -1,4 +1,6 @@
-import Differentiation as Diff
+from __future__ import print_function
+from __future__ import absolute_import
+from . import Differentiation as Diff
 import numpy as np
 import sys
 
@@ -132,6 +134,6 @@ def sadourny_sw(sim):
     elif sim.dynamics == 'Linear':
         sim.flux_function = sadourny_sw_linear_flux
     else:
-        print "dynamics must be from the list: Nonlinear, Linear"
+        print("dynamics must be from the list: Nonlinear, Linear")
         sys.exit()
             

--- a/src/Fluxes/SPECTRAL_SW.py
+++ b/src/Fluxes/SPECTRAL_SW.py
@@ -1,4 +1,6 @@
-import Differentiation as Diff
+from __future__ import print_function
+from __future__ import absolute_import
+from . import Differentiation as Diff
 import numpy as np
 import sys
 
@@ -147,7 +149,7 @@ def spectral_sw(sim):
     elif sim.dynamics == 'Linear':
         sim.flux_function = spectral_sw_linear_flux
     else:
-        print "dynamics must be from the list: Nonlinear, Linear"
+        print("dynamics must be from the list: Nonlinear, Linear")
         sys.exit()
             
     sim.apply_filter = filter_general

--- a/src/Fluxes/SPECTRAL_SW.py
+++ b/src/Fluxes/SPECTRAL_SW.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 from __future__ import absolute_import
+from builtins import range
 from . import Differentiation as Diff
 import numpy as np
 import sys

--- a/src/Fluxes/__init__.py
+++ b/src/Fluxes/__init__.py
@@ -1,8 +1,9 @@
+from __future__ import absolute_import
 # Fluxes
 #     This module provides the flux options
 #     for the simulator class.
 
 # FJP: if statement?
 # Import the flux options
-from SPECTRAL_SW import spectral_sw
-from SADOURNY_SW import sadourny_sw
+from .SPECTRAL_SW import spectral_sw
+from .SADOURNY_SW import sadourny_sw

--- a/src/Plot_tools/__init__.py
+++ b/src/Plot_tools/__init__.py
@@ -1,12 +1,13 @@
+from __future__ import absolute_import
 # Plot_tools
 #       This module provides the functions used
 #       for visualizing results from a PyRSW
 #       simulation
 
 # Import the plotting tools
-from initialize_plots_animsave_1D import initialize_plots_animsave_1D
-from initialize_plots_animsave_2D import initialize_plots_animsave_2D
-from initialize_plots_hov import initialize_plots_hov
-from plot_hov import plot_hov
-from update_hov import update_hov
-from smart_time import smart_time
+from .initialize_plots_animsave_1D import initialize_plots_animsave_1D
+from .initialize_plots_animsave_2D import initialize_plots_animsave_2D
+from .initialize_plots_hov import initialize_plots_hov
+from .plot_hov import plot_hov
+from .update_hov import update_hov
+from .smart_time import smart_time

--- a/src/Plot_tools/initialize_plots_animsave_1D.py
+++ b/src/Plot_tools/initialize_plots_animsave_1D.py
@@ -1,7 +1,10 @@
 from __future__ import absolute_import
+from __future__ import division
 # Initialize plot objects for anim or save
 # Assume that the field is 1-dimensional
 
+from builtins import range
+from past.utils import old_div
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -42,9 +45,9 @@ def initialize_plots_animsave_1D(sim):
                     to_plot = sim.soln.u[0:sim.Nx,0:sim.Ny,L]
 
                 if sim.Nx > 1:
-                    x = sim.grid_x.u/1e3
+                    x = old_div(sim.grid_x.u,1e3)
                 else:
-                    x = sim.grid_y.u/1e3
+                    x = old_div(sim.grid_y.u,1e3)
 
             elif var == 'v':
                 if sim.method.lower() == 'sadourny':
@@ -53,9 +56,9 @@ def initialize_plots_animsave_1D(sim):
                     to_plot = sim.soln.v[0:sim.Nx,0:sim.Ny,L]
 
                 if sim.Nx > 1:
-                    x = sim.grid_x.v/1e3
+                    x = old_div(sim.grid_x.v,1e3)
                 else:
-                    x = sim.grid_y.v/1e3
+                    x = old_div(sim.grid_y.v,1e3)
 
             elif var == 'h':
                 if sim.method.lower() == 'sadourny':
@@ -64,22 +67,22 @@ def initialize_plots_animsave_1D(sim):
                     to_plot = sim.soln.h[0:sim.Nx,0:sim.Ny,L] - sim.Hs[L]
 
                 if sim.Nx > 1:
-                    x = sim.grid_x.h/1e3
+                    x = old_div(sim.grid_x.h,1e3)
                 else:
-                    x = sim.grid_y.h/1e3
+                    x = old_div(sim.grid_y.h,1e3)
 
             elif var == 'vort':
                 to_plot = sim.ddx_v(sim.soln.v[:,:,L],sim) \
                         - sim.ddy_u(sim.soln.u[:,:,L],sim)
                 to_plot = to_plot.ravel()
                 if sim.f0 != 0:
-                    to_plot *= 1./sim.f0
+                    to_plot *= old_div(1.,sim.f0)
             elif var == 'div':
                 h = sim.soln.h[:,:,L].ravel() 
                 to_plot = sim.ddx_u(h*sim.soln.u[:,:,L],sim) \
                         + sim.ddy_v(h*sim.soln.v[:,:,L],sim)
                 if sim.f0 != 0:
-                    to_plot *= 1./sim.f0
+                    to_plot *= old_div(1.,sim.f0)
                 to_plot = to_plot.ravel()
 
             l, = plt.plot(x.ravel(), to_plot.ravel(), linewidth=2)

--- a/src/Plot_tools/initialize_plots_animsave_1D.py
+++ b/src/Plot_tools/initialize_plots_animsave_1D.py
@@ -1,11 +1,12 @@
+from __future__ import absolute_import
 # Initialize plot objects for anim or save
 # Assume that the field is 1-dimensional
 
 import matplotlib.pyplot as plt
 import numpy as np
 
-from update_anim_1D import update_anim_1D
-from update_save_1D import update_save_1D
+from .update_anim_1D import update_anim_1D
+from .update_save_1D import update_save_1D
 
 def initialize_plots_animsave_1D(sim):
 

--- a/src/Plot_tools/initialize_plots_animsave_1D.py
+++ b/src/Plot_tools/initialize_plots_animsave_1D.py
@@ -4,7 +4,6 @@ from __future__ import division
 # Assume that the field is 1-dimensional
 
 from builtins import range
-from past.utils import old_div
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -32,7 +31,7 @@ def initialize_plots_animsave_1D(sim):
         var = sim.plot_vars[var_cnt]
         Qs  += [[]]
         axs += [[]]
-    
+
 
         # Plot the data
         plt.subplot(len(sim.plot_vars),1,var_cnt+1)
@@ -45,9 +44,9 @@ def initialize_plots_animsave_1D(sim):
                     to_plot = sim.soln.u[0:sim.Nx,0:sim.Ny,L]
 
                 if sim.Nx > 1:
-                    x = old_div(sim.grid_x.u,1e3)
+                    x = sim.grid_x.u/1e3
                 else:
-                    x = old_div(sim.grid_y.u,1e3)
+                    x = sim.grid_y.u/1e3
 
             elif var == 'v':
                 if sim.method.lower() == 'sadourny':
@@ -56,9 +55,9 @@ def initialize_plots_animsave_1D(sim):
                     to_plot = sim.soln.v[0:sim.Nx,0:sim.Ny,L]
 
                 if sim.Nx > 1:
-                    x = old_div(sim.grid_x.v,1e3)
+                    x = sim.grid_x.v/1e3
                 else:
-                    x = old_div(sim.grid_y.v,1e3)
+                    x = sim.grid_y.v/1e3
 
             elif var == 'h':
                 if sim.method.lower() == 'sadourny':
@@ -67,22 +66,22 @@ def initialize_plots_animsave_1D(sim):
                     to_plot = sim.soln.h[0:sim.Nx,0:sim.Ny,L] - sim.Hs[L]
 
                 if sim.Nx > 1:
-                    x = old_div(sim.grid_x.h,1e3)
+                    x = sim.grid_x.h/1e3
                 else:
-                    x = old_div(sim.grid_y.h,1e3)
+                    x = sim.grid_y.h/1e3
 
             elif var == 'vort':
                 to_plot = sim.ddx_v(sim.soln.v[:,:,L],sim) \
                         - sim.ddy_u(sim.soln.u[:,:,L],sim)
                 to_plot = to_plot.ravel()
                 if sim.f0 != 0:
-                    to_plot *= old_div(1.,sim.f0)
+                    to_plot *= 1./sim.f0
             elif var == 'div':
-                h = sim.soln.h[:,:,L].ravel() 
+                h = sim.soln.h[:,:,L].ravel()
                 to_plot = sim.ddx_u(h*sim.soln.u[:,:,L],sim) \
                         + sim.ddy_v(h*sim.soln.v[:,:,L],sim)
                 if sim.f0 != 0:
-                    to_plot *= old_div(1.,sim.f0)
+                    to_plot *= 1./sim.f0
                 to_plot = to_plot.ravel()
 
             l, = plt.plot(x.ravel(), to_plot.ravel(), linewidth=2)
@@ -113,7 +112,6 @@ def initialize_plots_animsave_1D(sim):
         plt.ion()
         plt.pause(0.01)
         plt.draw()
-        
+
     sim.Qs  = Qs
     sim.axs = axs
-

--- a/src/Plot_tools/initialize_plots_animsave_2D.py
+++ b/src/Plot_tools/initialize_plots_animsave_2D.py
@@ -1,7 +1,10 @@
 from __future__ import absolute_import
+from __future__ import division
 # Initialize plot objects for anim or save
 # Assume that hte field is 2-dimensional
 
+from builtins import range
+from past.utils import old_div
 import numpy as np
 import matplotlib.pyplot as plt
 
@@ -70,7 +73,7 @@ def initialize_plots_animsave_2D(sim):
 
                 if sim.f0 != 0:
                     ttl = fig.suptitle('Vorticity / f_0 : t = 0')
-                    to_plot *= 1./sim.f0
+                    to_plot *= old_div(1.,sim.f0)
                 else:   
                     ttl = fig.suptitle('Vorticity : t = 0')
             elif var == 'div':
@@ -88,7 +91,7 @@ def initialize_plots_animsave_2D(sim):
 
                 if sim.f0 != 0:
                     ttl = fig.suptitle('Divergence of mass-flux / f_0 : t = 0')
-                    to_plot *= 1./sim.f0
+                    to_plot *= old_div(1.,sim.f0)
                 else:   
                     ttl = fig.suptitle('Divergence of mass-flux : t = 0')
 
@@ -107,15 +110,15 @@ def initialize_plots_animsave_2D(sim):
             X_plot = np.zeros((Nx+1,Ny+1))
             Y_plot = np.zeros((Nx+1,Ny+1))
 
-            X_plot[1:,1:] = X + sim.dx[0]/2.
-            X_plot[1:,0]  = X[:,0] + sim.dx[0]/2.
-            X_plot[0,:]   = X[0,0] - sim.dx[0]/2.
+            X_plot[1:,1:] = X + old_div(sim.dx[0],2.)
+            X_plot[1:,0]  = X[:,0] + old_div(sim.dx[0],2.)
+            X_plot[0,:]   = X[0,0] - old_div(sim.dx[0],2.)
 
-            Y_plot[1:,1:] = Y + sim.dx[1]/2.
-            Y_plot[0,1:]  = Y[0,:] + sim.dx[1]/2.
-            Y_plot[:,0]   = Y[0,0] - sim.dx[1]/2.
+            Y_plot[1:,1:] = Y + old_div(sim.dx[1],2.)
+            Y_plot[0,1:]  = Y[0,:] + old_div(sim.dx[1],2.)
+            Y_plot[:,0]   = Y[0,0] - old_div(sim.dx[1],2.)
 
-            Q = plt.pcolormesh(X_plot/1e3, Y_plot/1e3, to_plot, cmap=sim.cmap, 
+            Q = plt.pcolormesh(old_div(X_plot,1e3), old_div(Y_plot,1e3), to_plot, cmap=sim.cmap, 
                         vmin = vmin, vmax = vmax)
             Qs[var_cnt] += [Q]
             ttls[var_cnt] += [ttl]
@@ -124,7 +127,7 @@ def initialize_plots_animsave_2D(sim):
 
             plt.axis('tight')
 
-            if 1./1.1 <= sim.Ly/sim.Lx <= 1.1:
+            if old_div(1.,1.1) <= old_div(sim.Ly,sim.Lx) <= 1.1:
                 plt.gca().set_aspect('equal')
 
     if sim.animate == 'Anim':

--- a/src/Plot_tools/initialize_plots_animsave_2D.py
+++ b/src/Plot_tools/initialize_plots_animsave_2D.py
@@ -4,7 +4,6 @@ from __future__ import division
 # Assume that hte field is 2-dimensional
 
 from builtins import range
-from past.utils import old_div
 import numpy as np
 import matplotlib.pyplot as plt
 
@@ -59,7 +58,7 @@ def initialize_plots_animsave_2D(sim):
                 X = sim.grid_x.h
                 Y = sim.grid_y.h
             elif var == 'vort':
-                
+
                 if sim.method.lower() == 'sadourny':
                     to_plot =     sim.ddx_v(sim.soln.v[0:sim.Nx+1,0:sim.Ny,L],sim.dx[0]) \
                                 - sim.ddy_u(sim.soln.u[0:sim.Nx,0:sim.Ny+1,L],sim.dx[1])
@@ -67,14 +66,14 @@ def initialize_plots_animsave_2D(sim):
                 elif sim.method.lower() == 'spectral':
                     to_plot =     sim.ddx_v(sim.soln.v[0:sim.Nx,0:sim.Ny,L],sim) \
                                 - sim.ddy_u(sim.soln.u[0:sim.Nx,0:sim.Ny,L],sim)
-                
+
                 X = sim.grid_x.h
                 Y = sim.grid_y.h
 
                 if sim.f0 != 0:
                     ttl = fig.suptitle('Vorticity / f_0 : t = 0')
-                    to_plot *= old_div(1.,sim.f0)
-                else:   
+                    to_plot *= 1./sim.f0
+                else:
                     ttl = fig.suptitle('Vorticity : t = 0')
             elif var == 'div':
 
@@ -82,7 +81,7 @@ def initialize_plots_animsave_2D(sim):
                     to_plot =     sim.ddx_u(sim.avx_h(sim.soln.h[0:sim.Nx+1,0:sim.Ny+1,L])*sim.soln.u[0:sim.Nx,0:sim.Ny+1,L],sim.dx[0]) \
                                 + sim.ddy_v(sim.avy_h(sim.soln.h[0:sim.Nx+1,0:sim.Ny+1,L])*sim.soln.v[0:sim.Nx+1,0:sim.Ny,L],sim.dy[0])
                 elif sim.method.lower() == 'spectral':
-                    h = sim.soln.h[:,:,L] 
+                    h = sim.soln.h[:,:,L]
                     to_plot =     sim.ddx_u(h*sim.soln.u[0:Nx,0:Ny,L],sim) \
                                 + sim.ddy_v(h*sim.soln.v[0:Nx,0:Ny,L],sim)
 
@@ -91,8 +90,8 @@ def initialize_plots_animsave_2D(sim):
 
                 if sim.f0 != 0:
                     ttl = fig.suptitle('Divergence of mass-flux / f_0 : t = 0')
-                    to_plot *= old_div(1.,sim.f0)
-                else:   
+                    to_plot *= 1./sim.f0
+                else:
                     ttl = fig.suptitle('Divergence of mass-flux : t = 0')
 
             # Has the user specified plot limits?
@@ -110,15 +109,15 @@ def initialize_plots_animsave_2D(sim):
             X_plot = np.zeros((Nx+1,Ny+1))
             Y_plot = np.zeros((Nx+1,Ny+1))
 
-            X_plot[1:,1:] = X + old_div(sim.dx[0],2.)
-            X_plot[1:,0]  = X[:,0] + old_div(sim.dx[0],2.)
-            X_plot[0,:]   = X[0,0] - old_div(sim.dx[0],2.)
+            X_plot[1:,1:] = X + sim.dx[0]/2.
+            X_plot[1:,0]  = X[:,0] + sim.dx[0]/2.
+            X_plot[0,:]   = X[0,0] - sim.dx[0]/2.
 
-            Y_plot[1:,1:] = Y + old_div(sim.dx[1],2.)
-            Y_plot[0,1:]  = Y[0,:] + old_div(sim.dx[1],2.)
-            Y_plot[:,0]   = Y[0,0] - old_div(sim.dx[1],2.)
+            Y_plot[1:,1:] = Y + sim.dx[1]/2.
+            Y_plot[0,1:]  = Y[0,:] + sim.dx[1]/2.
+            Y_plot[:,0]   = Y[0,0] - sim.dx[1]/2.
 
-            Q = plt.pcolormesh(old_div(X_plot,1e3), old_div(Y_plot,1e3), to_plot, cmap=sim.cmap, 
+            Q = plt.pcolormesh(X_plot/1e3, Y_plot/1e3, to_plot, cmap=sim.cmap,
                         vmin = vmin, vmax = vmax)
             Qs[var_cnt] += [Q]
             ttls[var_cnt] += [ttl]
@@ -127,7 +126,7 @@ def initialize_plots_animsave_2D(sim):
 
             plt.axis('tight')
 
-            if old_div(1.,1.1) <= old_div(sim.Ly,sim.Lx) <= 1.1:
+            if 1./1.1 <= sim.Ly/sim.Lx <= 1.1:
                 plt.gca().set_aspect('equal')
 
     if sim.animate == 'Anim':
@@ -145,4 +144,3 @@ def initialize_plots_animsave_2D(sim):
     sim.figs = figs
     sim.Qs = Qs
     sim.ttls = ttls
-

--- a/src/Plot_tools/initialize_plots_animsave_2D.py
+++ b/src/Plot_tools/initialize_plots_animsave_2D.py
@@ -1,11 +1,12 @@
+from __future__ import absolute_import
 # Initialize plot objects for anim or save
 # Assume that hte field is 2-dimensional
 
 import numpy as np
 import matplotlib.pyplot as plt
 
-from update_anim_2D import update_anim_2D
-from update_save_2D import update_save_2D
+from .update_anim_2D import update_anim_2D
+from .update_save_2D import update_save_2D
 
 def initialize_plots_animsave_2D(sim):
 

--- a/src/Plot_tools/initialize_plots_hov.py
+++ b/src/Plot_tools/initialize_plots_hov.py
@@ -1,6 +1,5 @@
 from __future__ import division
 from builtins import range
-from past.utils import old_div
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -14,15 +13,15 @@ def initialize_plots_hov(sim):
     Qs = []
 
     # Plot h
-    t = old_div(np.arange(0,sim.end_time+sim.plott,sim.plott),86400.)
+    t = np.arange(0,sim.end_time+sim.plott,sim.plott)/86400.
 
     for L in range(sim.Nz):
         plt.subplot(sim.Nz,1,L+1)
         if sim.Nx > 1:
-            x = old_div(sim.x,1e3)
+            x = sim.x/1e3
             plt.xlabel('x (km)')
         if sim.Ny > 1:
-            x = old_div(sim.y,1e3)
+            x = sim.y/1e3
             plt.xlabel('y (km)')
         Q = plt.pcolormesh(x,t,sim.hov_h[:,L,:].T - np.sum(sim.Hs[L:]),cmap=sim.cmap)
         sim.vmin = list(range(sim.Nz))
@@ -34,7 +33,7 @@ def initialize_plots_hov(sim):
             tmp = np.max(np.abs(sim.hov_h[:,L,0] - np.sum(sim.Hs[L:])))
             sim.vmin[L] = -tmp
             sim.vmax[L] =  tmp
-        Q = plt.pcolormesh(x,t[:2],sim.hov_h[:,L,:2].T - np.sum(sim.Hs[L:]),cmap=sim.cmap, 
+        Q = plt.pcolormesh(x,t[:2],sim.hov_h[:,L,:2].T - np.sum(sim.Hs[L:]),cmap=sim.cmap,
                 vmin = sim.vmin[L], vmax = sim.vmax[L])
         plt.ylim((t[0],t[-1]))
         plt.axis('tight')
@@ -50,4 +49,3 @@ def initialize_plots_hov(sim):
     plt.ion()
     plt.pause(0.01)
     plt.draw()
-

--- a/src/Plot_tools/initialize_plots_hov.py
+++ b/src/Plot_tools/initialize_plots_hov.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from builtins import range
+from past.utils import old_div
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -11,19 +14,19 @@ def initialize_plots_hov(sim):
     Qs = []
 
     # Plot h
-    t = np.arange(0,sim.end_time+sim.plott,sim.plott)/86400.
+    t = old_div(np.arange(0,sim.end_time+sim.plott,sim.plott),86400.)
 
     for L in range(sim.Nz):
         plt.subplot(sim.Nz,1,L+1)
         if sim.Nx > 1:
-            x = sim.x/1e3
+            x = old_div(sim.x,1e3)
             plt.xlabel('x (km)')
         if sim.Ny > 1:
-            x = sim.y/1e3
+            x = old_div(sim.y,1e3)
             plt.xlabel('y (km)')
         Q = plt.pcolormesh(x,t,sim.hov_h[:,L,:].T - np.sum(sim.Hs[L:]),cmap=sim.cmap)
-        sim.vmin = range(sim.Nz)
-        sim.vmax = range(sim.Nz)
+        sim.vmin = list(range(sim.Nz))
+        sim.vmax = list(range(sim.Nz))
         if len(sim.ylims[2]) == 2:
             sim.vmin[L] = sim.ylims[2][0]
             sim.vmax[L] = sim.ylims[2][1]

--- a/src/Plot_tools/plot_hov.py
+++ b/src/Plot_tools/plot_hov.py
@@ -1,15 +1,18 @@
+from __future__ import division
 # Create Hovmuller plot at end of anim simulation
+from builtins import range
+from past.utils import old_div
 import matplotlib.pyplot as plt
 import numpy as np
 
 def plot_hov(sim):
     plt.figure()
-    t = np.arange(0,sim.end_time+sim.plott,sim.plott)/86400.
+    t = old_div(np.arange(0,sim.end_time+sim.plott,sim.plott),86400.)
 
     if sim.Ny==1:
-        x = sim.x/1e3
+        x = old_div(sim.x,1e3)
     elif sim.Nx == 1:
-        x = sim.y/1e3
+        x = old_div(sim.y,1e3)
 
     for L in range(sim.Nz):
         field = sim.hov_h[:,0,:].T - np.sum(sim.Hs[L:])

--- a/src/Plot_tools/plot_hov.py
+++ b/src/Plot_tools/plot_hov.py
@@ -1,18 +1,17 @@
 from __future__ import division
 # Create Hovmuller plot at end of anim simulation
 from builtins import range
-from past.utils import old_div
 import matplotlib.pyplot as plt
 import numpy as np
 
 def plot_hov(sim):
     plt.figure()
-    t = old_div(np.arange(0,sim.end_time+sim.plott,sim.plott),86400.)
+    t = np.arange(0,sim.end_time+sim.plott,sim.plott)/86400.
 
     if sim.Ny==1:
-        x = old_div(sim.x,1e3)
+        x = sim.x/1e3
     elif sim.Nx == 1:
-        x = old_div(sim.y,1e3)
+        x = sim.y/1e3
 
     for L in range(sim.Nz):
         field = sim.hov_h[:,0,:].T - np.sum(sim.Hs[L:])
@@ -28,4 +27,3 @@ def plot_hov(sim):
             plt.xlabel(r"$\mathrm{y} \; \mathrm{(km)}$", fontsize=14)
         plt.ylabel(r"$\mathrm{Time} \; \mathrm{(days)}$", fontsize=14)
         plt.colorbar()
-

--- a/src/Plot_tools/smart_time.py
+++ b/src/Plot_tools/smart_time.py
@@ -1,14 +1,16 @@
+from __future__ import division
 # Helper for formatting time strings
+from past.utils import old_div
 def smart_time(t):
     tstr = 't = '
 
     if t < 2*60.:
         tstr += '{0:.4f} sec'.format(t)
     elif t < 90.*60:
-        tstr += '{0:.4f} min'.format(t/60)
+        tstr += '{0:.4f} min'.format(old_div(t,60))
     elif t < 48.*60*60:
-        tstr += '{0:.4f} hrs'.format(t/(60*60))
+        tstr += '{0:.4f} hrs'.format(old_div(t,(60*60)))
     else:
-        tstr += '{0:.4f} day'.format(t/(24*60*60))
+        tstr += '{0:.4f} day'.format(old_div(t,(24*60*60)))
 
     return tstr

--- a/src/Plot_tools/smart_time.py
+++ b/src/Plot_tools/smart_time.py
@@ -1,16 +1,15 @@
 from __future__ import division
 # Helper for formatting time strings
-from past.utils import old_div
 def smart_time(t):
     tstr = 't = '
 
     if t < 2*60.:
         tstr += '{0:.4f} sec'.format(t)
     elif t < 90.*60:
-        tstr += '{0:.4f} min'.format(old_div(t,60))
+        tstr += '{0:.4f} min'.format(t/60)
     elif t < 48.*60*60:
-        tstr += '{0:.4f} hrs'.format(old_div(t,(60*60)))
+        tstr += '{0:.4f} hrs'.format(t/(60*60))
     else:
-        tstr += '{0:.4f} day'.format(old_div(t,(24*60*60)))
+        tstr += '{0:.4f} day'.format(t/(24*60*60))
 
     return tstr

--- a/src/Plot_tools/update_anim_1D.py
+++ b/src/Plot_tools/update_anim_1D.py
@@ -1,7 +1,10 @@
 from __future__ import absolute_import
+from __future__ import division
 # Update plot objects if animating
 # Assume that the field is 1-dimensional
 
+from builtins import range
+from past.utils import old_div
 import matplotlib.pyplot as plt
 import numpy as np
 from .smart_time import smart_time
@@ -37,14 +40,14 @@ def update_anim_1D(sim):
                         - sim.ddy_u(sim.soln.u[:,:,L],sim)
                 to_plot = to_plot.ravel()
                 if sim.f0 != 0:
-                    to_plot *= 1./sim.f0
+                    to_plot *= old_div(1.,sim.f0)
             elif var == 'div':
                 h = sim.soln.h[:,:,L] 
                 to_plot = sim.ddx_u(h*sim.soln.u[:,:,L],sim) \
                         + sim.ddy_v(h*sim.soln.v[:,:,L],sim)
                 to_plot = to_plot.ravel()
                 if sim.f0 != 0:
-                    to_plot *= 1./sim.f0
+                    to_plot *= old_div(1.,sim.f0)
 
 
             sim.Qs[var_cnt][L].set_ydata(to_plot)

--- a/src/Plot_tools/update_anim_1D.py
+++ b/src/Plot_tools/update_anim_1D.py
@@ -4,7 +4,6 @@ from __future__ import division
 # Assume that the field is 1-dimensional
 
 from builtins import range
-from past.utils import old_div
 import matplotlib.pyplot as plt
 import numpy as np
 from .smart_time import smart_time
@@ -40,24 +39,23 @@ def update_anim_1D(sim):
                         - sim.ddy_u(sim.soln.u[:,:,L],sim)
                 to_plot = to_plot.ravel()
                 if sim.f0 != 0:
-                    to_plot *= old_div(1.,sim.f0)
+                    to_plot *= 1./sim.f0
             elif var == 'div':
-                h = sim.soln.h[:,:,L] 
+                h = sim.soln.h[:,:,L]
                 to_plot = sim.ddx_u(h*sim.soln.u[:,:,L],sim) \
                         + sim.ddy_v(h*sim.soln.v[:,:,L],sim)
                 to_plot = to_plot.ravel()
                 if sim.f0 != 0:
-                    to_plot *= old_div(1.,sim.f0)
+                    to_plot *= 1./sim.f0
 
 
             sim.Qs[var_cnt][L].set_ydata(to_plot)
 
-            if len(sim.ylims[var_cnt]) != 2: 
+            if len(sim.ylims[var_cnt]) != 2:
                 sim.axs[var_cnt][L].relim()
                 tmp = sim.axs[var_cnt][L].get_ylim()
                 sim.axs[var_cnt][L].set_ylim([-np.max(np.abs(tmp)), np.max(np.abs(tmp))]);
                 sim.axs[var_cnt][L].autoscale_view()
 
-    plt.pause(0.01) 
+    plt.pause(0.01)
     plt.draw()
-

--- a/src/Plot_tools/update_anim_1D.py
+++ b/src/Plot_tools/update_anim_1D.py
@@ -1,9 +1,10 @@
+from __future__ import absolute_import
 # Update plot objects if animating
 # Assume that the field is 1-dimensional
 
 import matplotlib.pyplot as plt
 import numpy as np
-from smart_time import smart_time
+from .smart_time import smart_time
 
 def update_anim_1D(sim):
 

--- a/src/Plot_tools/update_anim_2D.py
+++ b/src/Plot_tools/update_anim_2D.py
@@ -1,5 +1,8 @@
 from __future__ import absolute_import
+from __future__ import division
 # Update plot objects if animating
+from builtins import range
+from past.utils import old_div
 import numpy as np
 from .smart_time import smart_time
 import matplotlib.pyplot as plt
@@ -43,7 +46,7 @@ def update_anim_2D(sim):
                 
                 if sim.f0 != 0:
                     sim.ttls[var_cnt][L].set_text('Vorticity / f_0 : {0:s}'.format(smart_time(sim.time)))
-                    to_plot *= 1./sim.f0
+                    to_plot *= old_div(1.,sim.f0)
                 else:   
                     sim.ttls[var_cnt][L].set_text('Vorticity : {0:s}'.format(smart_time(sim.time)))
             elif var == 'div':
@@ -58,7 +61,7 @@ def update_anim_2D(sim):
 
                 if sim.f0 != 0:
                     sim.ttls[var_cnt][L].set_text('Divergence of mass-flux / f_0 : {0:s}'.format(smart_time(sim.time)))
-                    to_plot *= 1./sim.f0
+                    to_plot *= old_div(1.,sim.f0)
                 else:   
                     sim.ttls[var_cnt][L].set_text('Divergence of mass-flux : {0:s}'.format(smart_time(sim.time)))
 

--- a/src/Plot_tools/update_anim_2D.py
+++ b/src/Plot_tools/update_anim_2D.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 from __future__ import division
 # Update plot objects if animating
 from builtins import range
-from past.utils import old_div
 import numpy as np
 from .smart_time import smart_time
 import matplotlib.pyplot as plt
@@ -35,7 +34,7 @@ def update_anim_2D(sim):
                 elif sim.method.lower() == 'spectral':
                     to_plot = sim.soln.h[0:sim.Nx,0:sim.Ny,L] - sim.Hs[L]
             elif var == 'vort':
-                
+
                 if sim.method.lower() == 'sadourny':
                     to_plot =     sim.ddx_v(sim.soln.v[0:sim.Nx+1,0:sim.Ny,L],sim.dx[0]) \
                                 - sim.ddy_u(sim.soln.u[0:sim.Nx,0:sim.Ny+1,L],sim.dx[1])
@@ -43,11 +42,11 @@ def update_anim_2D(sim):
                 elif sim.method.lower() == 'spectral':
                     to_plot =     sim.ddx_v(sim.soln.v[0:sim.Nx,0:sim.Ny,L],sim) \
                                 - sim.ddy_u(sim.soln.u[0:sim.Nx,0:sim.Ny,L],sim)
-                
+
                 if sim.f0 != 0:
                     sim.ttls[var_cnt][L].set_text('Vorticity / f_0 : {0:s}'.format(smart_time(sim.time)))
-                    to_plot *= old_div(1.,sim.f0)
-                else:   
+                    to_plot *= 1./sim.f0
+                else:
                     sim.ttls[var_cnt][L].set_text('Vorticity : {0:s}'.format(smart_time(sim.time)))
             elif var == 'div':
 
@@ -55,20 +54,17 @@ def update_anim_2D(sim):
                     to_plot =     sim.ddx_u(sim.avx_h(sim.soln.h[0:sim.Nx+1,0:sim.Ny+1,L])*sim.soln.u[0:sim.Nx,0:sim.Ny+1,L],sim.dx[0]) \
                                 + sim.ddy_v(sim.avy_h(sim.soln.h[0:sim.Nx+1,0:sim.Ny+1,L])*sim.soln.v[0:sim.Nx+1,0:sim.Ny,L],sim.dy[0])
                 elif sim.method.lower() == 'spectral':
-                    h = sim.soln.h[:,:,L] 
+                    h = sim.soln.h[:,:,L]
                     to_plot =     sim.ddx_u(h*sim.soln.u[0:Nx,0:Ny,L],sim) \
                                 + sim.ddy_v(h*sim.soln.v[0:Nx,0:Ny,L],sim)
 
                 if sim.f0 != 0:
                     sim.ttls[var_cnt][L].set_text('Divergence of mass-flux / f_0 : {0:s}'.format(smart_time(sim.time)))
-                    to_plot *= old_div(1.,sim.f0)
-                else:   
+                    to_plot *= 1./sim.f0
+                else:
                     sim.ttls[var_cnt][L].set_text('Divergence of mass-flux : {0:s}'.format(smart_time(sim.time)))
 
             sim.Qs[var_cnt][L].set_array(to_plot.ravel())
             sim.Qs[var_cnt][L].changed()
-        plt.pause(0.01) 
+        plt.pause(0.01)
     plt.draw()
-
-
-

--- a/src/Plot_tools/update_anim_2D.py
+++ b/src/Plot_tools/update_anim_2D.py
@@ -1,6 +1,7 @@
+from __future__ import absolute_import
 # Update plot objects if animating
 import numpy as np
-from smart_time import smart_time
+from .smart_time import smart_time
 import matplotlib.pyplot as plt
 
 def update_anim_2D(sim):

--- a/src/Plot_tools/update_hov.py
+++ b/src/Plot_tools/update_hov.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 from __future__ import division
-from past.utils import old_div
 import matplotlib.pyplot as plt
 import numpy as np
 from .smart_time import smart_time
@@ -10,9 +9,8 @@ def update_hov(sim):
     sim.fig.suptitle(smart_time(sim.time))
     if sim.Nx > 1:
         sim.hov_h[:,:,sim.hov_count] = sim.soln.h[:,0,:-1]
-        x = old_div(sim.x,1e3)
+        x = sim.x/1e3
     else:
-        sim.hov_h[:,:,sim.hov_count] = sim.soln.h[0,:,:-1] 
-        x = old_div(sim.y,1e3)
+        sim.hov_h[:,:,sim.hov_count] = sim.soln.h[0,:,:-1]
+        x = sim.y/1e3
     sim.hov_count += 1
-

--- a/src/Plot_tools/update_hov.py
+++ b/src/Plot_tools/update_hov.py
@@ -1,4 +1,6 @@
 from __future__ import absolute_import
+from __future__ import division
+from past.utils import old_div
 import matplotlib.pyplot as plt
 import numpy as np
 from .smart_time import smart_time
@@ -8,9 +10,9 @@ def update_hov(sim):
     sim.fig.suptitle(smart_time(sim.time))
     if sim.Nx > 1:
         sim.hov_h[:,:,sim.hov_count] = sim.soln.h[:,0,:-1]
-        x = sim.x/1e3
+        x = old_div(sim.x,1e3)
     else:
         sim.hov_h[:,:,sim.hov_count] = sim.soln.h[0,:,:-1] 
-        x = sim.y/1e3
+        x = old_div(sim.y,1e3)
     sim.hov_count += 1
 

--- a/src/Plot_tools/update_hov.py
+++ b/src/Plot_tools/update_hov.py
@@ -1,6 +1,7 @@
+from __future__ import absolute_import
 import matplotlib.pyplot as plt
 import numpy as np
-from smart_time import smart_time
+from .smart_time import smart_time
 
 def update_hov(sim):
 

--- a/src/Plot_tools/update_save_1D.py
+++ b/src/Plot_tools/update_save_1D.py
@@ -1,9 +1,10 @@
+from __future__ import absolute_import
 # Update plot objects if saving
 # Assume the field is 1-dimensional
 
 import matplotlib.pyplot as plt
 import numpy as np
-from smart_time import smart_time
+from .smart_time import smart_time
 
 def update_save_1D(sim):
 

--- a/src/Plot_tools/update_save_1D.py
+++ b/src/Plot_tools/update_save_1D.py
@@ -1,7 +1,10 @@
 from __future__ import absolute_import
+from __future__ import division
 # Update plot objects if saving
 # Assume the field is 1-dimensional
 
+from builtins import range
+from past.utils import old_div
 import matplotlib.pyplot as plt
 import numpy as np
 from .smart_time import smart_time
@@ -37,14 +40,14 @@ def update_save_1D(sim):
                         - sim.ddy_u(sim.soln.u[:,:,L],sim)
                 to_plot = to_plot.ravel()
                 if sim.f0 != 0:
-                    to_plot *= 1./sim.f0
+                    to_plot *= old_div(1.,sim.f0)
             elif var == 'div':
                 h = sim.soln.h[:,:,L]
                 to_plot = sim.ddx_u(h*sim.soln.u[:,:,L],sim) \
                         + sim.ddy_v(h*sim.soln.v[:,:,L],sim)
                 to_plot = to_plot.ravel()
                 if sim.f0 != 0:
-                    to_plot *= 1./sim.f0
+                    to_plot *= old_div(1.,sim.f0)
 
 
             sim.Qs[var_cnt][L].set_ydata(to_plot)

--- a/src/Plot_tools/update_save_1D.py
+++ b/src/Plot_tools/update_save_1D.py
@@ -4,7 +4,6 @@ from __future__ import division
 # Assume the field is 1-dimensional
 
 from builtins import range
-from past.utils import old_div
 import matplotlib.pyplot as plt
 import numpy as np
 from .smart_time import smart_time
@@ -40,19 +39,19 @@ def update_save_1D(sim):
                         - sim.ddy_u(sim.soln.u[:,:,L],sim)
                 to_plot = to_plot.ravel()
                 if sim.f0 != 0:
-                    to_plot *= old_div(1.,sim.f0)
+                    to_plot *= 1./sim.f0
             elif var == 'div':
                 h = sim.soln.h[:,:,L]
                 to_plot = sim.ddx_u(h*sim.soln.u[:,:,L],sim) \
                         + sim.ddy_v(h*sim.soln.v[:,:,L],sim)
                 to_plot = to_plot.ravel()
                 if sim.f0 != 0:
-                    to_plot *= old_div(1.,sim.f0)
+                    to_plot *= 1./sim.f0
 
 
             sim.Qs[var_cnt][L].set_ydata(to_plot)
 
-            if len(sim.ylims[var_cnt]) != 2: 
+            if len(sim.ylims[var_cnt]) != 2:
                 sim.axs[var_cnt][L].relim()
                 tmp = sim.axs[var][L].get_ylim()
                 sim.axs[var_cnt][L].set_ylim([-np.max(np.abs(tmp)), np.max(np.abs(tmp))]);
@@ -62,4 +61,3 @@ def update_save_1D(sim):
 
     sim.fig.savefig('Outputs/{0:s}/Frames/frame_{1:05d}.png'.format(sim.run_name,sim.frame_count))
     sim.frame_count += 1
-

--- a/src/Plot_tools/update_save_2D.py
+++ b/src/Plot_tools/update_save_2D.py
@@ -1,5 +1,8 @@
 from __future__ import absolute_import
+from __future__ import division
 # Update plot objects if saving
+from builtins import range
+from past.utils import old_div
 import numpy as np
 from .smart_time import smart_time
 import matplotlib.pyplot as plt
@@ -43,7 +46,7 @@ def update_save_2D(sim):
                 
                 if sim.f0 != 0:
                     sim.ttls[var_cnt][L].set_text('Vorticity / f_0 : {0:s}'.format(smart_time(sim.time)))
-                    to_plot *= 1./sim.f0
+                    to_plot *= old_div(1.,sim.f0)
                 else:   
                     sim.ttls[var_cnt][L].set_text('Vorticity : {0:s}'.format(smart_time(sim.time)))
             elif var == 'div':
@@ -58,7 +61,7 @@ def update_save_2D(sim):
 
                 if sim.f0 != 0:
                     sim.ttls[var_cnt][L].set_text('Divergence of mass-flux / f_0 : {0:s}'.format(smart_time(sim.time)))
-                    to_plot *= 1./sim.f0
+                    to_plot *= old_div(1.,sim.f0)
                 else:   
                     sim.ttls[var_cnt][L].set_text('Divergence of mass-flux : {0:s}'.format(smart_time(sim.time)))
 

--- a/src/Plot_tools/update_save_2D.py
+++ b/src/Plot_tools/update_save_2D.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 from __future__ import division
 # Update plot objects if saving
 from builtins import range
-from past.utils import old_div
 import numpy as np
 from .smart_time import smart_time
 import matplotlib.pyplot as plt
@@ -35,7 +34,7 @@ def update_save_2D(sim):
                 elif sim.method.lower() == 'spectral':
                     to_plot = sim.soln.h[0:sim.Nx,0:sim.Ny,L] - sim.Hs[L]
             elif var == 'vort':
-                
+
                 if sim.method.lower() == 'sadourny':
                     to_plot =     sim.ddx_v(sim.soln.v[0:sim.Nx+1,0:sim.Ny,L],sim.dx[0]) \
                                 - sim.ddy_u(sim.soln.u[0:sim.Nx,0:sim.Ny+1,L],sim.dx[1])
@@ -43,11 +42,11 @@ def update_save_2D(sim):
                 elif sim.method.lower() == 'spectral':
                     to_plot =     sim.ddx_v(sim.soln.v[0:sim.Nx,0:sim.Ny,L],sim) \
                                 - sim.ddy_u(sim.soln.u[0:sim.Nx,0:sim.Ny,L],sim)
-                
+
                 if sim.f0 != 0:
                     sim.ttls[var_cnt][L].set_text('Vorticity / f_0 : {0:s}'.format(smart_time(sim.time)))
-                    to_plot *= old_div(1.,sim.f0)
-                else:   
+                    to_plot *= 1./sim.f0
+                else:
                     sim.ttls[var_cnt][L].set_text('Vorticity : {0:s}'.format(smart_time(sim.time)))
             elif var == 'div':
 
@@ -55,14 +54,14 @@ def update_save_2D(sim):
                     to_plot =     sim.ddx_u(sim.avx_h(sim.soln.h[0:sim.Nx+1,0:sim.Ny+1,L])*sim.soln.u[0:sim.Nx,0:sim.Ny+1,L],sim.dx[0]) \
                                 + sim.ddy_v(sim.avy_h(sim.soln.h[0:sim.Nx+1,0:sim.Ny+1,L])*sim.soln.v[0:sim.Nx+1,0:sim.Ny,L],sim.dy[0])
                 elif sim.method.lower() == 'spectral':
-                    h = sim.soln.h[:,:,L] 
+                    h = sim.soln.h[:,:,L]
                     to_plot =     sim.ddx_u(h*sim.soln.u[0:Nx,0:Ny,L],sim) \
                                 + sim.ddy_v(h*sim.soln.v[0:Nx,0:Ny,L],sim)
 
                 if sim.f0 != 0:
                     sim.ttls[var_cnt][L].set_text('Divergence of mass-flux / f_0 : {0:s}'.format(smart_time(sim.time)))
-                    to_plot *= old_div(1.,sim.f0)
-                else:   
+                    to_plot *= 1./sim.f0
+                else:
                     sim.ttls[var_cnt][L].set_text('Divergence of mass-flux : {0:s}'.format(smart_time(sim.time)))
 
             sim.Qs[var_cnt][L].set_array(to_plot.ravel())
@@ -72,4 +71,3 @@ def update_save_2D(sim):
         sim.figs[var_cnt].savefig('Outputs/{0:s}/Frames/{1:s}_{2:05d}.png'.format(sim.run_name,var,sim.frame_count))
 
     sim.frame_count += 1
-

--- a/src/Plot_tools/update_save_2D.py
+++ b/src/Plot_tools/update_save_2D.py
@@ -1,6 +1,7 @@
+from __future__ import absolute_import
 # Update plot objects if saving
 import numpy as np
-from smart_time import smart_time
+from .smart_time import smart_time
 import matplotlib.pyplot as plt
 
 def update_save_2D(sim):

--- a/src/PyRsw.py
+++ b/src/PyRsw.py
@@ -1,9 +1,13 @@
 from __future__ import print_function
+from __future__ import division
 ##
 ## This file contains the core PyRsw user class.
 ##
 
 
+from builtins import map
+from past.utils import old_div
+from builtins import object
 import numpy as np
 import matplotlib
 import Plot_tools
@@ -21,13 +25,13 @@ def null_topo(a_sim):
     return
 
 #FJP: why do we have 2 layers of u,v,h if Nz = 0?
-class Solution():
+class Solution(object):
     def __init__(self,Nx,Ny,Nz):
         self.u = np.zeros((Nx,Ny,Nz+1))
         self.v = np.zeros((Nx,Ny,Nz+1))
         self.h = np.zeros((Nx,Ny,Nz+1))
 
-class SolutionSd():
+class SolutionSd(object):
     def __init__(self,Nx,Ny,Nz):
         if Nx == 1:
             self.u = np.zeros((1, Ny+1, Nz))
@@ -42,13 +46,13 @@ class SolutionSd():
             self.v = np.zeros((Nx+1, Ny,   Nz))
             self.h = np.zeros((Nx+1, Ny+1, Nz+1))
 
-class Flux():
+class Flux(object):
     def __init__(self):
         self.u = []
         self.v = []
         self.h = []
 
-class Simulation:
+class Simulation(object):
 
     # First-level initialization, default values
     def __init__(self):
@@ -172,24 +176,24 @@ class Simulation:
         # x,  y:   centre values
         # xe, ye:  edge values
         
-        dx = self.Lx/self.Nx
-        self.x = np.arange(dx/2,self.Lx,dx)    - self.Lx/2.
+        dx = old_div(self.Lx,self.Nx)
+        self.x = np.arange(old_div(dx,2),self.Lx,dx)    - old_div(self.Lx,2.)
         dxs[0] = dx
 
-        dy = self.Ly/self.Ny
-        self.y = np.arange(dy/2,self.Ly,dy)    - self.Ly/2.
+        dy = old_div(self.Ly,self.Ny)
+        self.y = np.arange(old_div(dy,2),self.Ly,dy)    - old_div(self.Ly,2.)
         dxs[1] = dy
 
         [self.X, self.Y]  = np.meshgrid(self.x, self.y, indexing='ij')
 
         if self.method.lower() == 'sadourny':
             if self.Nx > 1:
-                xe = np.arange(0.0, self.Lx+dx,dx) - self.Lx/2.
+                xe = np.arange(0.0, self.Lx+dx,dx) - old_div(self.Lx,2.)
                 #xe.reshape((self.Nx+1,1))
             else:
                 xe = np.array([0.0])
             if self.Ny > 1:
-                ye = np.arange(0.0, self.Ly+dy,dy) - self.Ly/2.
+                ye = np.arange(0.0, self.Ly+dy,dy) - old_div(self.Ly,2.)
                 #ye.reshape((1,self.Ny+1))
             else:
                 ye = np.array([0.0])
@@ -235,15 +239,15 @@ class Simulation:
             ford = self.ford
             fstr = self.fstr
             if self.Nx>1:
-                k = self.kx/max(self.kx.ravel())
-                filtx = np.exp(-fstr*((np.abs(k)-fcut)/(1-fcut))**ford)*(np.abs(k)>fcut) + (np.abs(k)<fcut)
+                k = old_div(self.kx,max(self.kx.ravel()))
+                filtx = np.exp(-fstr*(old_div((np.abs(k)-fcut),(1-fcut)))**ford)*(np.abs(k)>fcut) + (np.abs(k)<fcut)
                 filtx = filtx.reshape((self.Nkx,1))
             else:
                 filtx = np.array([1.0])
                 
             if self.Ny>1:
-                k = self.ky/max(self.ky.ravel())
-                filty = np.exp(-fstr*((np.abs(k)-fcut)/(1-fcut))**ford)*(np.abs(k)>fcut) + (np.abs(k)<fcut)
+                k = old_div(self.ky,max(self.ky.ravel()))
+                filty = np.exp(-fstr*(old_div((np.abs(k)-fcut),(1-fcut)))**ford)*(np.abs(k)>fcut) + (np.abs(k)<fcut)
                 filty = filty.reshape((1,self.Nky))
             else:
                 filty = np.array([1.0])
@@ -252,15 +256,15 @@ class Simulation:
 
         # If we're using a fixed dt, check that it matches plott, savet, and diagt
         if self.animate.lower() != 'none':
-            if self.plott/self.fixed_dt != int(self.plott/self.fixed_dt):
+            if old_div(self.plott,self.fixed_dt) != int(old_div(self.plott,self.fixed_dt)):
                 print('Error: Plot interval not integer multiple of fixed dt.')
                 sys.exit()
         if self.diagnose:
-            if self.diagt/self.fixed_dt != int(self.diagt/self.fixed_dt):
+            if old_div(self.diagt,self.fixed_dt) != int(old_div(self.diagt,self.fixed_dt)):
                 print('Error: Diagnostic interval not integer multiple of fixed dt.')
                 sys.exit()
         if self.output:
-            if self.savet/self.fixed_dt != int(self.savet/self.fixed_dt):
+            if old_div(self.savet,self.fixed_dt) != int(old_div(self.savet,self.fixed_dt)):
                 print('Error: Output interval not integer multiple of fixed dt.')
                 sys.exit()
 
@@ -302,7 +306,7 @@ class Simulation:
                 self.ylims += [[]]*(len(self.plot_vars) - len(self.ylims))
                 self.initialize_plots = Plot_tools.initialize_plots_animsave_1D
         
-            num_plot = self.end_time/self.plott+1
+            num_plot = old_div(self.end_time,self.plott)+1
             #FJP: not ready for Sadourny
             #if (self.Nx > 1) and (self.Ny == 1):
             #    self.hov_h = np.zeros((self.Nx,self.Nz,num_plot))
@@ -316,7 +320,7 @@ class Simulation:
 
             if not(self.restarting):
                 self.update_plots(self)
-            self.frame_count = int(np.floor(self.time/self.plott) + 1)
+            self.frame_count = int(np.floor(old_div(self.time,self.plott)) + 1)
             self.next_plot_time = self.frame_count*self.plott
 
     # Compute the current flux
@@ -390,7 +394,7 @@ class Simulation:
             self.next_save_time += self.savet
 
         # Update the records
-        self.mean_dt = (self.mean_dt*self.num_steps + self.dt)/(self.num_steps+1)
+        self.mean_dt = old_div((self.mean_dt*self.num_steps + self.dt),(self.num_steps+1))
         self.num_steps += 1
 
         if do_plot or self.time == self.dt:
@@ -418,7 +422,7 @@ class Simulation:
                 pstr += ', min(u,v,h) = ({0: < 8.4e},{1: < 8.4e},{2: < 8.4e})'.format(minu,minv,minh)
                 #pstr += ', del_mass = {0: .2g}'.format(mass/self.Ms[0]-1)
                 pstr += '\n'
-                tmp = '  = {0:.3%}'.format(self.time/self.end_time)
+                tmp = '  = {0:.3%}'.format(old_div(self.time,self.end_time))
                 pstr += tmp
                 pstr += ' '*(L - len(tmp))            
                 pstr += 'avg = {0:0<7.1e}'.format(self.mean_dt)
@@ -433,7 +437,7 @@ class Simulation:
                 #pstr += ', del_mass = {0:+.2g}'.format(mass/self.Ms[0]-1)
                 #pstr += ', del_enrg = {0:+.2g}'.format(enrg/(self.KEs[0]+self.PEs[0])-1)
                 pstr += '\n'
-                pstr += '  = {0:.3%}'.format(self.time/self.end_time)
+                pstr += '  = {0:.3%}'.format(old_div(self.time,self.end_time))
 
             head_str = ('\n{0:s}'.format(self.run_name))
             if self.animate != 'None':
@@ -489,22 +493,22 @@ class Simulation:
             max_u = np.max(np.abs(self.soln.u.ravel()))
             max_v = np.max(np.abs(self.soln.v.ravel()))
 
-            dt_x = self.end_time - ((self.Nx-1)/(self.Nx-1+eps))*(self.end_time - self.dx[0]/(max_u+2*c))
-            dt_y = self.end_time - ((self.Ny-1)/(self.Ny-1+eps))*(self.end_time - self.dx[1]/(max_v+2*c))
+            dt_x = self.end_time - (old_div((self.Nx-1),(self.Nx-1+eps)))*(self.end_time - old_div(self.dx[0],(max_u+2*c)))
+            dt_y = self.end_time - (old_div((self.Ny-1),(self.Ny-1+eps)))*(self.end_time - old_div(self.dx[1],(max_v+2*c)))
 
             self.dt = max([self.cfl*min([dt_x,dt_y]),self.min_dt])
 
             # If using an adaptive timestep, slowing increase dt
             # over the first 20 steps.
             if self.num_steps <= 20:
-                self.dt *= 1./(5*(21 - self.num_steps))
+                self.dt *= old_div(1.,(5*(21 - self.num_steps)))
         else:
             self.dt = self.fixed_dt
 
 
         # Slowly ramp-up the dt for the first 20 steps
         if self.num_steps <= 20:
-            self.dt *= 1./(5*(21-self.num_steps))
+            self.dt *= old_div(1.,(5*(21-self.num_steps)))
 
     # Initialize the saving
     def initialize_saving(self):
@@ -570,5 +574,5 @@ class Simulation:
 
     # Helper to write arrays
     def array2str(fp,arr):
-        s = '[' + reduce(lambda s1,s2: s1+', '+s2, map(str,arr)) + ']'
+        s = '[' + reduce(lambda s1,s2: s1+', '+s2, list(map(str,arr))) + ']'
         return s

--- a/src/PyRsw.py
+++ b/src/PyRsw.py
@@ -6,7 +6,6 @@ from __future__ import division
 
 
 from builtins import map
-from past.utils import old_div
 from builtins import object
 import numpy as np
 import matplotlib
@@ -37,7 +36,7 @@ class SolutionSd(object):
             self.u = np.zeros((1, Ny+1, Nz))
             self.v = np.zeros((1, Ny,   Nz))
             self.h = np.zeros((1, Ny+1, Nz+1))
-        elif Ny == 1:    
+        elif Ny == 1:
             self.u = np.zeros((Nx,   1, Nz))
             self.v = np.zeros((Nx+1, 1, Nz))
             self.h = np.zeros((Nx+1, 1, Nz+1))
@@ -66,7 +65,7 @@ class Simulation(object):
 
         self.nfluxes = 0            # Length of flux history
         self.fluxes = Flux()
-        
+
         self.method = 'Spectral'    # Spectral or Finite Volume (FV)?
 
         self.dynamics = 'Nonlinear' # Nonlinear or Linear
@@ -76,7 +75,7 @@ class Simulation(object):
         self.plot_vars = ['u','v','h']         # Which variables to plot
         self.ylims = []
         self.clims = []
-        
+
         self.g    = 9.81            # gravity
         self.f0   = 1e-4            # Coriolis
         self.beta = 0.
@@ -90,7 +89,7 @@ class Simulation(object):
         self.geomy = 'periodic'     # y boundary condition
 
         self.cmap = 'seismic'       # Default colour map
-        
+
         self.run_name = 'test'      # Name of variable
 
         #FJP: only spectral
@@ -115,7 +114,7 @@ class Simulation(object):
         self.restart_index = 0
 
         self.topo_func = null_topo  # Default to no topograpy
-        
+
     # Full initialization for once the user has specified parameters
     def initialize(self):
 
@@ -168,32 +167,32 @@ class Simulation(object):
         if self.restarting:
             print('Restarting from index {0:d}'.format(self.restart_index))
         print(' ')
-        
+
 
         # Initialize grids and cell centres
         dxs = [1,1]
 
         # x,  y:   centre values
         # xe, ye:  edge values
-        
-        dx = old_div(self.Lx,self.Nx)
-        self.x = np.arange(old_div(dx,2),self.Lx,dx)    - old_div(self.Lx,2.)
+
+        dx = self.Lx/self.Nx
+        self.x = np.arange(dx/2,self.Lx,dx)    - self.Lx/2.
         dxs[0] = dx
 
-        dy = old_div(self.Ly,self.Ny)
-        self.y = np.arange(old_div(dy,2),self.Ly,dy)    - old_div(self.Ly,2.)
+        dy = self.Ly/self.Ny
+        self.y = np.arange(dy/2,self.Ly,dy)    - self.Ly/2.
         dxs[1] = dy
 
         [self.X, self.Y]  = np.meshgrid(self.x, self.y, indexing='ij')
 
         if self.method.lower() == 'sadourny':
             if self.Nx > 1:
-                xe = np.arange(0.0, self.Lx+dx,dx) - old_div(self.Lx,2.)
+                xe = np.arange(0.0, self.Lx+dx,dx) - self.Lx/2.
                 #xe.reshape((self.Nx+1,1))
             else:
                 xe = np.array([0.0])
             if self.Ny > 1:
-                ye = np.arange(0.0, self.Ly+dy,dy) - old_div(self.Ly,2.)
+                ye = np.arange(0.0, self.Ly+dy,dy) - self.Ly/2.
                 #ye.reshape((1,self.Ny+1))
             else:
                 ye = np.array([0.0])
@@ -239,36 +238,36 @@ class Simulation(object):
             ford = self.ford
             fstr = self.fstr
             if self.Nx>1:
-                k = old_div(self.kx,max(self.kx.ravel()))
-                filtx = np.exp(-fstr*(old_div((np.abs(k)-fcut),(1-fcut)))**ford)*(np.abs(k)>fcut) + (np.abs(k)<fcut)
+                k = self.kx/max(self.kx.ravel())
+                filtx = np.exp(-fstr*((np.abs(k)-fcut)/(1-fcut))**ford)*(np.abs(k)>fcut) + (np.abs(k)<fcut)
                 filtx = filtx.reshape((self.Nkx,1))
             else:
                 filtx = np.array([1.0])
-                
+
             if self.Ny>1:
-                k = old_div(self.ky,max(self.ky.ravel()))
-                filty = np.exp(-fstr*(old_div((np.abs(k)-fcut),(1-fcut)))**ford)*(np.abs(k)>fcut) + (np.abs(k)<fcut)
+                k = self.ky/max(self.ky.ravel())
+                filty = np.exp(-fstr*((np.abs(k)-fcut)/(1-fcut))**ford)*(np.abs(k)>fcut) + (np.abs(k)<fcut)
                 filty = filty.reshape((1,self.Nky))
             else:
                 filty = np.array([1.0])
-                
+
             self.sfilt = np.tile(filtx,(1,self.Nky))*np.tile(filty,(self.Nkx,1))
 
         # If we're using a fixed dt, check that it matches plott, savet, and diagt
         if self.animate.lower() != 'none':
-            if old_div(self.plott,self.fixed_dt) != int(old_div(self.plott,self.fixed_dt)):
+            if self.plott/self.fixed_dt != int(self.plott/self.fixed_dt):
                 print('Error: Plot interval not integer multiple of fixed dt.')
                 sys.exit()
         if self.diagnose:
-            if old_div(self.diagt,self.fixed_dt) != int(old_div(self.diagt,self.fixed_dt)):
+            if self.diagt/self.fixed_dt != int(self.diagt/self.fixed_dt):
                 print('Error: Diagnostic interval not integer multiple of fixed dt.')
                 sys.exit()
         if self.output:
-            if old_div(self.savet,self.fixed_dt) != int(old_div(self.savet,self.fixed_dt)):
+            if self.savet/self.fixed_dt != int(self.savet/self.fixed_dt):
                 print('Error: Output interval not integer multiple of fixed dt.')
                 sys.exit()
 
-            
+
         # If we're restarting load the appropriate files
         if self.restarting:
             try:
@@ -281,18 +280,18 @@ class Simulation(object):
                 print('Restarting failed. Exiting.')
                 sys.exit()
 
-        
+
     def prepare_for_run(self):
 
         #FJP: not ready for Sadourny
         # If we're going to be diagnosing, initialize those
         #Diagnose.initialize_diagnostics(self)
-    
+
         # If we're saving, initialize those too
         if self.output:
             self.next_save_time = (self.restart_index+1)*self.savet
             self.out_counter = self.restart_index
-    
+
         # If we're saving, initialize the directory
         if self.output or (self.animate == 'Save') or self.diagnose:
             self.initialize_saving()
@@ -305,8 +304,8 @@ class Simulation(object):
             else:
                 self.ylims += [[]]*(len(self.plot_vars) - len(self.ylims))
                 self.initialize_plots = Plot_tools.initialize_plots_animsave_1D
-        
-            num_plot = old_div(self.end_time,self.plott)+1
+
+            num_plot = self.end_time/self.plott+1
             #FJP: not ready for Sadourny
             #if (self.Nx > 1) and (self.Ny == 1):
             #    self.hov_h = np.zeros((self.Nx,self.Nz,num_plot))
@@ -320,7 +319,7 @@ class Simulation(object):
 
             if not(self.restarting):
                 self.update_plots(self)
-            self.frame_count = int(np.floor(old_div(self.time,self.plott)) + 1)
+            self.frame_count = int(np.floor(self.time/self.plott) + 1)
             self.next_plot_time = self.frame_count*self.plott
 
     # Compute the current flux
@@ -329,7 +328,7 @@ class Simulation(object):
 
     # Adjust time-step when necessary
     def adjust_dt(self):
-        
+
         t = self.time + self.dt
 
         nt = self.end_time # next time for doing stuff
@@ -365,8 +364,8 @@ class Simulation(object):
     # Advance the simulation one time-step.
     def step(self):
 
-        self.compute_dt() 
-        
+        self.compute_dt()
+
         # Check if we need to adjust the time-step
         # to match an output time
         do_plot, do_diag, do_save = self.adjust_dt()
@@ -378,7 +377,7 @@ class Simulation(object):
             self.apply_filter(self)
 
         self.time += self.dt
-       
+
         if do_plot:
             self.update_plots(self)
             self.next_plot_time += self.plott
@@ -394,7 +393,7 @@ class Simulation(object):
             self.next_save_time += self.savet
 
         # Update the records
-        self.mean_dt = old_div((self.mean_dt*self.num_steps + self.dt),(self.num_steps+1))
+        self.mean_dt = (self.mean_dt*self.num_steps + self.dt)/(self.num_steps+1)
         self.num_steps += 1
 
         if do_plot or self.time == self.dt:
@@ -407,7 +406,7 @@ class Simulation(object):
             minu = np.min(np.ravel(self.soln.u[:,:,0]))
             maxv = np.max(np.ravel(self.soln.v[:,:,0]))
             minv = np.min(np.ravel(self.soln.v[:,:,0]))
-            
+
             #mass = Diagnose.compute_mass(self)
             #enrg = Diagnose.compute_PE(self) + Diagnose.compute_KE(self)
 
@@ -422,9 +421,9 @@ class Simulation(object):
                 pstr += ', min(u,v,h) = ({0: < 8.4e},{1: < 8.4e},{2: < 8.4e})'.format(minu,minv,minh)
                 #pstr += ', del_mass = {0: .2g}'.format(mass/self.Ms[0]-1)
                 pstr += '\n'
-                tmp = '  = {0:.3%}'.format(old_div(self.time,self.end_time))
+                tmp = '  = {0:.3%}'.format(self.time/self.end_time)
                 pstr += tmp
-                pstr += ' '*(L - len(tmp))            
+                pstr += ' '*(L - len(tmp))
                 pstr += 'avg = {0:0<7.1e}'.format(self.mean_dt)
                 pstr += ', max(u,v,h) = ({0: < 8.4e},{1: < 8.4e},{2: < 8.4e})'.format(maxu,maxv,maxh)
                 #pstr += ', del_enrg = {0: .2g}'.format(enrg/(self.KEs[0]+self.PEs[0])-1)
@@ -437,7 +436,7 @@ class Simulation(object):
                 #pstr += ', del_mass = {0:+.2g}'.format(mass/self.Ms[0]-1)
                 #pstr += ', del_enrg = {0:+.2g}'.format(enrg/(self.KEs[0]+self.PEs[0])-1)
                 pstr += '\n'
-                pstr += '  = {0:.3%}'.format(old_div(self.time,self.end_time))
+                pstr += '  = {0:.3%}'.format(self.time/self.end_time)
 
             head_str = ('\n{0:s}'.format(self.run_name))
             if self.animate != 'None':
@@ -466,7 +465,7 @@ class Simulation(object):
 
         #if self.diagnose:
         #    Diagnose.plot(self)
-        
+
         #if (self.animate == 'Anim'):
             #print "h at x = 0 and t = ", self.time
             #plt.figure()
@@ -493,22 +492,22 @@ class Simulation(object):
             max_u = np.max(np.abs(self.soln.u.ravel()))
             max_v = np.max(np.abs(self.soln.v.ravel()))
 
-            dt_x = self.end_time - (old_div((self.Nx-1),(self.Nx-1+eps)))*(self.end_time - old_div(self.dx[0],(max_u+2*c)))
-            dt_y = self.end_time - (old_div((self.Ny-1),(self.Ny-1+eps)))*(self.end_time - old_div(self.dx[1],(max_v+2*c)))
+            dt_x = self.end_time - ((self.Nx-1)/(self.Nx-1+eps))*(self.end_time - self.dx[0]/(max_u+2*c))
+            dt_y = self.end_time - ((self.Ny-1)/(self.Ny-1+eps))*(self.end_time - self.dx[1]/(max_v+2*c))
 
             self.dt = max([self.cfl*min([dt_x,dt_y]),self.min_dt])
 
             # If using an adaptive timestep, slowing increase dt
             # over the first 20 steps.
             if self.num_steps <= 20:
-                self.dt *= old_div(1.,(5*(21 - self.num_steps)))
+                self.dt *= 1./(5*(21 - self.num_steps))
         else:
             self.dt = self.fixed_dt
 
 
         # Slowly ramp-up the dt for the first 20 steps
         if self.num_steps <= 20:
-            self.dt *= old_div(1.,(5*(21-self.num_steps)))
+            self.dt *= 1./(5*(21-self.num_steps))
 
     # Initialize the saving
     def initialize_saving(self):
@@ -521,7 +520,7 @@ class Simulation(object):
             # If directory already exists, delete it.
             if os.path.isdir(path):
                print('Output directory {0:s} already exists. '.format(path) + \
-                     'Warning, deleting everything in the directory.') 
+                     'Warning, deleting everything in the directory.')
                shutil.rmtree(path)
             # Make directory.
             os.mkdir(path)
@@ -555,9 +554,9 @@ class Simulation(object):
         fp.close()
 
     #FJP: modify for new grid sizes
-    # Save grid 
+    # Save grid
     def save_grid(self):
-        fname = 'Outputs/{0:s}/grid'.format(self.run_name) 
+        fname = 'Outputs/{0:s}/grid'.format(self.run_name)
         if self.Nx > 1 and self.Ny > 1:
             np.savez_compressed(fname, x = self.x, y = self.y, X = self.X, Y = self.Y)
         elif self.Nx > 1:

--- a/src/PyRsw.py
+++ b/src/PyRsw.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 ##
 ## This file contains the core PyRsw user class.
 ##
@@ -14,6 +15,7 @@ from scipy.fftpack import fftn, ifftn, fftfreq
 import os, sys, shutil
 #FJP
 import matplotlib.pyplot as plt
+from functools import reduce
 
 def null_topo(a_sim):
     return
@@ -161,7 +163,7 @@ class Simulation:
                 print('Coriolis = f-plane')
         if self.restarting:
             print('Restarting from index {0:d}'.format(self.restart_index))
-        print ' '
+        print(' ')
         
 
         # Initialize grids and cell centres

--- a/src/Stability_tools.py
+++ b/src/Stability_tools.py
@@ -1,4 +1,5 @@
 from __future__ import division
+from builtins import range
 import numpy as np
 import scipy.linalg as spalg
 import matplotlib.pyplot as plt
@@ -16,9 +17,9 @@ def cheb(N):
         D = 0
         x = 1
     else:
-        x = np.cos(np.pi*np.array(range(0,N+1))/N).reshape([N+1,1])
+        x = np.cos(np.pi*np.array(list(range(0,N+1)))/N).reshape([N+1,1])
         c = np.ravel(np.vstack([2, np.ones([N-1,1]), 2])) \
-            *(-1)**np.ravel(np.array(range(0,N+1)))
+            *(-1)**np.ravel(np.array(list(range(0,N+1))))
         c = c.reshape(c.shape[0],1)
         X = np.tile(x,(1,N+1))
         dX = X-(X.conj().transpose())

--- a/src/Steppers/AB2.py
+++ b/src/Steppers/AB2.py
@@ -1,5 +1,6 @@
+from __future__ import absolute_import
 import numpy as np
-from Euler import Euler
+from .Euler import Euler
 
 def AB2(sim):
     if sim.nfluxes < 1:

--- a/src/Steppers/AB3.py
+++ b/src/Steppers/AB3.py
@@ -1,4 +1,6 @@
 from __future__ import absolute_import
+from __future__ import division
+from past.utils import old_div
 import numpy as np
 from .Euler import Euler
 from .AB2 import AB2
@@ -33,17 +35,17 @@ def AB3(sim):
             a  = sim.time - sim.dts[0]
             b  = sim.time - sim.dts[0] - sim.dts[1]
 
-            w0 = sim.dt*((1./3)*gam1 - 0.5*gam2*(a+b) + a*b*gam3) / (sim.dts[0]*(sim.dts[0]+sim.dts[1]))
+            w0 = sim.dt*((old_div(1.,3))*gam1 - 0.5*gam2*(a+b) + a*b*gam3) / (sim.dts[0]*(sim.dts[0]+sim.dts[1]))
 
             a  = sim.time
             b  = sim.time - sim.dts[0] - sim.dts[1]
 
-            w1 = sim.dt*((1./3)*gam1 - 0.5*gam2*(a+b) + a*b*gam3) / (-sim.dts[0]*sim.dts[1])
+            w1 = sim.dt*((old_div(1.,3))*gam1 - 0.5*gam2*(a+b) + a*b*gam3) / (-sim.dts[0]*sim.dts[1])
 
             a  = sim.time
             b  = sim.time - sim.dts[0]
 
-            w2 = sim.dt*((1./3)*gam1 - 0.5*gam2*(a+b) + a*b*gam3) / ((sim.dts[0]+sim.dts[1])*sim.dts[1])
+            w2 = sim.dt*((old_div(1.,3))*gam1 - 0.5*gam2*(a+b) + a*b*gam3) / ((sim.dts[0]+sim.dts[1])*sim.dts[1])
         else:
             # Compute the weights for the fixed delta(t)
             # Adams-Bashforth 3 scheme

--- a/src/Steppers/AB3.py
+++ b/src/Steppers/AB3.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 from __future__ import division
-from past.utils import old_div
 import numpy as np
 from .Euler import Euler
 from .AB2 import AB2
@@ -35,17 +34,17 @@ def AB3(sim):
             a  = sim.time - sim.dts[0]
             b  = sim.time - sim.dts[0] - sim.dts[1]
 
-            w0 = sim.dt*((old_div(1.,3))*gam1 - 0.5*gam2*(a+b) + a*b*gam3) / (sim.dts[0]*(sim.dts[0]+sim.dts[1]))
+            w0 = sim.dt*((1./3)*gam1 - 0.5*gam2*(a+b) + a*b*gam3) / (sim.dts[0]*(sim.dts[0]+sim.dts[1]))
 
             a  = sim.time
             b  = sim.time - sim.dts[0] - sim.dts[1]
 
-            w1 = sim.dt*((old_div(1.,3))*gam1 - 0.5*gam2*(a+b) + a*b*gam3) / (-sim.dts[0]*sim.dts[1])
+            w1 = sim.dt*((1./3)*gam1 - 0.5*gam2*(a+b) + a*b*gam3) / (-sim.dts[0]*sim.dts[1])
 
             a  = sim.time
             b  = sim.time - sim.dts[0]
 
-            w2 = sim.dt*((old_div(1.,3))*gam1 - 0.5*gam2*(a+b) + a*b*gam3) / ((sim.dts[0]+sim.dts[1])*sim.dts[1])
+            w2 = sim.dt*((1./3)*gam1 - 0.5*gam2*(a+b) + a*b*gam3) / ((sim.dts[0]+sim.dts[1])*sim.dts[1])
         else:
             # Compute the weights for the fixed delta(t)
             # Adams-Bashforth 3 scheme
@@ -57,7 +56,7 @@ def AB3(sim):
         sim.soln.u += w0*sim.curr_flux.u + w1*sim.fluxes.u[0] + w2*sim.fluxes.u[1]
         sim.soln.v += w0*sim.curr_flux.v + w1*sim.fluxes.v[0] + w2*sim.fluxes.v[1]
         sim.soln.h += w0*sim.curr_flux.h + w1*sim.fluxes.h[0] + w2*sim.fluxes.h[1]
-        
+
         # Store the appropriate histories.
         if sim.nfluxes == 2:
             sim.fluxes.u = [sim.curr_flux.u.copy(), sim.fluxes.u[0].copy()]

--- a/src/Steppers/AB3.py
+++ b/src/Steppers/AB3.py
@@ -1,6 +1,7 @@
+from __future__ import absolute_import
 import numpy as np
-from Euler import Euler
-from AB2 import AB2
+from .Euler import Euler
+from .AB2 import AB2
 
 def AB3(sim):
     if sim.nfluxes < 2:

--- a/src/Steppers/RK4.py
+++ b/src/Steppers/RK4.py
@@ -1,3 +1,5 @@
+from __future__ import division
+from past.utils import old_div
 import numpy as np
 import sys
 
@@ -46,6 +48,6 @@ def RK4(sim):
     k4_v = flux_v + src_v
     k4_h = flux_h + src_h
 
-    sim.soln.u += -k3_u*sim.dt + (sim.dt/6.)*(k1_u + 2.*k2_u + 2.*k3_u + k4_u)
-    sim.soln.v += -k3_v*sim.dt + (sim.dt/6.)*(k1_v + 2.*k2_v + 2.*k3_v + k4_v)
-    sim.soln.h += -k3_h*sim.dt + (sim.dt/6.)*(k1_h + 2.*k2_h + 2.*k3_h + k4_h)
+    sim.soln.u += -k3_u*sim.dt + (old_div(sim.dt,6.))*(k1_u + 2.*k2_u + 2.*k3_u + k4_u)
+    sim.soln.v += -k3_v*sim.dt + (old_div(sim.dt,6.))*(k1_v + 2.*k2_v + 2.*k3_v + k4_v)
+    sim.soln.h += -k3_h*sim.dt + (old_div(sim.dt,6.))*(k1_h + 2.*k2_h + 2.*k3_h + k4_h)

--- a/src/Steppers/RK4.py
+++ b/src/Steppers/RK4.py
@@ -1,5 +1,4 @@
 from __future__ import division
-from past.utils import old_div
 import numpy as np
 import sys
 
@@ -48,6 +47,6 @@ def RK4(sim):
     k4_v = flux_v + src_v
     k4_h = flux_h + src_h
 
-    sim.soln.u += -k3_u*sim.dt + (old_div(sim.dt,6.))*(k1_u + 2.*k2_u + 2.*k3_u + k4_u)
-    sim.soln.v += -k3_v*sim.dt + (old_div(sim.dt,6.))*(k1_v + 2.*k2_v + 2.*k3_v + k4_v)
-    sim.soln.h += -k3_h*sim.dt + (old_div(sim.dt,6.))*(k1_h + 2.*k2_h + 2.*k3_h + k4_h)
+    sim.soln.u += -k3_u*sim.dt + (sim.dt/6.)*(k1_u + 2.*k2_u + 2.*k3_u + k4_u)
+    sim.soln.v += -k3_v*sim.dt + (sim.dt/6.)*(k1_v + 2.*k2_v + 2.*k3_v + k4_v)
+    sim.soln.h += -k3_h*sim.dt + (sim.dt/6.)*(k1_h + 2.*k2_h + 2.*k3_h + k4_h)

--- a/src/Steppers/__init__.py
+++ b/src/Steppers/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 # Steppers
 #    This module provides the time-stepping
 #    functions used for the simulator class.
@@ -6,7 +7,7 @@ __author__ = "Ben Storer <bastorer@uwaterloo.ca>"
 __date__   = "16th of March, 2015"
 
 # Import the functions
-from Euler import Euler
-from AB2 import AB2
-from AB3 import AB3
-from RK4 import RK4
+from .Euler import Euler
+from .AB2 import AB2
+from .AB3 import AB3
+from .RK4 import RK4

--- a/testing/test_1d_accuracy/test_linear_waves.py
+++ b/testing/test_1d_accuracy/test_linear_waves.py
@@ -1,6 +1,5 @@
 from __future__ import division
 from builtins import range
-from past.utils import old_div
 import numpy as np
 import matplotlib.pyplot as plt
 import sys
@@ -15,46 +14,46 @@ from constants import minute, hour, day
 
 def test():
 
-    sim = Simulation() 
+    sim = Simulation()
 
     # Geometry and Model Equations
     sim.geomy       = 'periodic'
-    sim.stepper     = Step.AB3      
-    sim.method      = 'Spectral'     
-    sim.dynamics    = 'Linear'     
-    sim.flux_method = Flux.spectral_sw 
+    sim.stepper     = Step.AB3
+    sim.method      = 'Spectral'
+    sim.dynamics    = 'Linear'
+    sim.flux_method = Flux.spectral_sw
 
     # Specify paramters
-    sim.Ly  = 4000e3   
-    sim.Ny  = 256       
+    sim.Ly  = 4000e3
+    sim.Ny  = 256
     sim.f0  = 0.
-    sim.Hs  = [100.]      
-    sim.rho = [1025.]      
-    sim.end_time = old_div(sim.Ly,(np.sqrt(sim.Hs[0]*sim.g)))
+    sim.Hs  = [100.]
+    sim.rho = [1025.]
+    sim.end_time = sim.Ly/(np.sqrt(sim.Hs[0]*sim.g))
 
     # Plotting parameters
     sim.animate = 'None'
     sim.output = False
-    sim.diagnose = False 
+    sim.diagnose = False
 
     # Initialize the grid and zero solutions
     sim.initialize()
 
-    for ii in range(sim.Nz): 
+    for ii in range(sim.Nz):
         sim.soln.h[:,:,ii] = sim.Hs[ii]
 
     # Gaussian initial conditions
-    x0 = 1.*sim.Lx/2.     
-    W  = 200.e3          
-    amp = 1.            
-    sim.soln.h[:,:,0] += amp*np.exp(old_div(-(sim.Y)**2,(W**2)))
+    x0 = 1.*sim.Lx/2.
+    W  = 200.e3
+    amp = 1.
+    sim.soln.h[:,:,0] += amp*np.exp(-(sim.Y)**2/(W**2))
     IC = sim.soln.h[:,:,0].copy()
 
-    sim.run()       
+    sim.run()
 
     # Compare final state to initial conditions
     # error_h is normalized using the triangle inequality
-    error_h = old_div(np.linalg.norm(IC - sim.soln.h[:,:,0]),(np.linalg.norm(IC) + np.linalg.norm(sim.soln.h[:,:,0])))
+    error_h = np.linalg.norm(IC - sim.soln.h[:,:,0])/(np.linalg.norm(IC) + np.linalg.norm(sim.soln.h[:,:,0]))
     error_v = np.linalg.norm(sim.soln.v[:,:,0])
     assert (error_h < 1e-6) and (error_v < 5e-5)
 

--- a/testing/test_1d_accuracy/test_linear_waves.py
+++ b/testing/test_1d_accuracy/test_linear_waves.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from builtins import range
+from past.utils import old_div
 import numpy as np
 import matplotlib.pyplot as plt
 import sys
@@ -27,7 +30,7 @@ def test():
     sim.f0  = 0.
     sim.Hs  = [100.]      
     sim.rho = [1025.]      
-    sim.end_time = sim.Ly/(np.sqrt(sim.Hs[0]*sim.g))
+    sim.end_time = old_div(sim.Ly,(np.sqrt(sim.Hs[0]*sim.g)))
 
     # Plotting parameters
     sim.animate = 'None'
@@ -44,14 +47,14 @@ def test():
     x0 = 1.*sim.Lx/2.     
     W  = 200.e3          
     amp = 1.            
-    sim.soln.h[:,:,0] += amp*np.exp(-(sim.Y)**2/(W**2))
+    sim.soln.h[:,:,0] += amp*np.exp(old_div(-(sim.Y)**2,(W**2)))
     IC = sim.soln.h[:,:,0].copy()
 
     sim.run()       
 
     # Compare final state to initial conditions
     # error_h is normalized using the triangle inequality
-    error_h = np.linalg.norm(IC - sim.soln.h[:,:,0])/(np.linalg.norm(IC) + np.linalg.norm(sim.soln.h[:,:,0]))
+    error_h = old_div(np.linalg.norm(IC - sim.soln.h[:,:,0]),(np.linalg.norm(IC) + np.linalg.norm(sim.soln.h[:,:,0])))
     error_v = np.linalg.norm(sim.soln.v[:,:,0])
     assert (error_h < 1e-6) and (error_v < 5e-5)
 

--- a/testing/test_1d_accuracy/test_linear_waves.py
+++ b/testing/test_1d_accuracy/test_linear_waves.py
@@ -2,7 +2,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 import sys
 
-sys.path.append('../src')
+sys.path.append('../../src')
 
 import Steppers as Step
 import Fluxes as Flux

--- a/testing/test_does_1d_run/test_periodic.py
+++ b/testing/test_does_1d_run/test_periodic.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from builtins import range
+from past.utils import old_div
 import numpy as np
 import matplotlib.pyplot as plt
 import sys
@@ -44,6 +47,6 @@ def test():
     x0 = 1.*sim.Lx/2.
     W  = 200.e3
     amp = 1.
-    sim.soln.h[:,:,0] += amp*np.exp(-(sim.Y)**2/(W**2))
+    sim.soln.h[:,:,0] += amp*np.exp(old_div(-(sim.Y)**2,(W**2)))
 
     sim.run()

--- a/testing/test_does_1d_run/test_periodic.py
+++ b/testing/test_does_1d_run/test_periodic.py
@@ -2,7 +2,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 import sys
 
-sys.path.append('../src')
+sys.path.append('../../src')
 
 import Steppers as Step
 import Fluxes as Flux
@@ -12,38 +12,38 @@ from constants import minute, hour, day
 
 def test():
 
-    sim = Simulation() 
+    sim = Simulation()
 
     # Geometry and Model Equations
     sim.geomy       = 'periodic'
-    sim.stepper     = Step.AB3      
-    sim.method      = 'Spectral'     
-    sim.dynamics    = 'Nonlinear'     
-    sim.flux_method = Flux.spectral_sw 
+    sim.stepper     = Step.AB3
+    sim.method      = 'Spectral'
+    sim.dynamics    = 'Nonlinear'
+    sim.flux_method = Flux.spectral_sw
 
     # Specify paramters
-    sim.Ly  = 4000e3   
-    sim.Ny  = 128       
-    sim.cfl = 0.5        
-    sim.Hs  = [100.]      
-    sim.rho = [1025.]      
+    sim.Ly  = 4000e3
+    sim.Ny  = 128
+    sim.cfl = 0.5
+    sim.Hs  = [100.]
+    sim.rho = [1025.]
     sim.end_time = 5.*minute
 
     # Plotting parameters
-    sim.animate = 'None'  
-    sim.output = False   
-    sim.diagnose = False 
+    sim.animate = 'None'
+    sim.output = False
+    sim.diagnose = False
 
     # Initialize the grid and zero solutions
     sim.initialize()
 
-    for ii in range(sim.Nz): 
+    for ii in range(sim.Nz):
         sim.soln.h[:,:,ii] = sim.Hs[ii]
 
     # Gaussian initial conditions
-    x0 = 1.*sim.Lx/2.     
-    W  = 200.e3          
-    amp = 1.            
+    x0 = 1.*sim.Lx/2.
+    W  = 200.e3
+    amp = 1.
     sim.soln.h[:,:,0] += amp*np.exp(-(sim.Y)**2/(W**2))
 
-    sim.run()       
+    sim.run()

--- a/testing/test_does_1d_run/test_periodic.py
+++ b/testing/test_does_1d_run/test_periodic.py
@@ -1,6 +1,5 @@
 from __future__ import division
 from builtins import range
-from past.utils import old_div
 import numpy as np
 import matplotlib.pyplot as plt
 import sys
@@ -47,6 +46,6 @@ def test():
     x0 = 1.*sim.Lx/2.
     W  = 200.e3
     amp = 1.
-    sim.soln.h[:,:,0] += amp*np.exp(old_div(-(sim.Y)**2,(W**2)))
+    sim.soln.h[:,:,0] += amp*np.exp(-(sim.Y)**2/(W**2))
 
     sim.run()

--- a/testing/test_does_1d_run/test_walls.py
+++ b/testing/test_does_1d_run/test_walls.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from builtins import range
+from past.utils import old_div
 import numpy as np
 import matplotlib.pyplot as plt
 import sys
@@ -44,6 +47,6 @@ def test():
     x0 = 1.*sim.Lx/2.
     W  = 200.e3
     amp = 1.
-    sim.soln.h[:,:,0] += amp*np.exp(-(sim.Y)**2/(W**2))
+    sim.soln.h[:,:,0] += amp*np.exp(old_div(-(sim.Y)**2,(W**2)))
 
     sim.run()

--- a/testing/test_does_1d_run/test_walls.py
+++ b/testing/test_does_1d_run/test_walls.py
@@ -2,7 +2,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 import sys
 
-sys.path.append('../src')
+sys.path.append('../../src')
 
 import Steppers as Step
 import Fluxes as Flux
@@ -12,39 +12,38 @@ from constants import minute, hour, day
 
 def test():
 
-    sim = Simulation() 
+    sim = Simulation()
 
     # Geometry and Model Equations
-    sim.geomy       = 'walls' 
-    sim.stepper     = Step.AB3      
-    sim.method      = 'Spectral'     
-    sim.dynamics    = 'Nonlinear'     
-    sim.flux_method = Flux.spectral_sw 
+    sim.geomy       = 'walls'
+    sim.stepper     = Step.AB3
+    sim.method      = 'Spectral'
+    sim.dynamics    = 'Nonlinear'
+    sim.flux_method = Flux.spectral_sw
 
     # Specify paramters
-    sim.Ly  = 4000e3   
-    sim.Ny  = 128       
-    sim.cfl = 0.5        
-    sim.Hs  = [100.]      
-    sim.rho = [1025.]      
+    sim.Ly  = 4000e3
+    sim.Ny  = 128
+    sim.cfl = 0.5
+    sim.Hs  = [100.]
+    sim.rho = [1025.]
     sim.end_time = 5.*minute
 
     # Plotting parameters
-    sim.animate = 'None'  
-    sim.output = False   
-    sim.diagnose = False 
+    sim.animate = 'None'
+    sim.output = False
+    sim.diagnose = False
 
     # Initialize the grid and zero solutions
     sim.initialize()
 
-    for ii in range(sim.Nz): 
+    for ii in range(sim.Nz):
         sim.soln.h[:,:,ii] = sim.Hs[ii]
 
     # Gaussian initial conditions
-    x0 = 1.*sim.Lx/2.     
-    W  = 200.e3          
-    amp = 1.            
+    x0 = 1.*sim.Lx/2.
+    W  = 200.e3
+    amp = 1.
     sim.soln.h[:,:,0] += amp*np.exp(-(sim.Y)**2/(W**2))
 
-    sim.run()      
-   
+    sim.run()

--- a/testing/test_does_1d_run/test_walls.py
+++ b/testing/test_does_1d_run/test_walls.py
@@ -1,6 +1,5 @@
 from __future__ import division
 from builtins import range
-from past.utils import old_div
 import numpy as np
 import matplotlib.pyplot as plt
 import sys
@@ -47,6 +46,6 @@ def test():
     x0 = 1.*sim.Lx/2.
     W  = 200.e3
     amp = 1.
-    sim.soln.h[:,:,0] += amp*np.exp(old_div(-(sim.Y)**2,(W**2)))
+    sim.soln.h[:,:,0] += amp*np.exp(-(sim.Y)**2/(W**2))
 
     sim.run()

--- a/testing/test_does_2d_run/test_periodic_periodic.py
+++ b/testing/test_does_2d_run/test_periodic_periodic.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from builtins import range
+from past.utils import old_div
 import numpy as np
 import matplotlib.pyplot as plt
 import sys
@@ -52,7 +55,7 @@ def test():
     # Gaussian initial conditions
     W  = 200.e3                # Width
     amp = 1.                  # Amplitude
-    sim.soln.h[:,:,0] += amp*np.exp(-(sim.X/W)**2 - (sim.Y/W)**2)
+    sim.soln.h[:,:,0] += amp*np.exp(-(old_div(sim.X,W))**2 - (old_div(sim.Y,W))**2)
 
     # Run the simulation
     sim.run()

--- a/testing/test_does_2d_run/test_periodic_periodic.py
+++ b/testing/test_does_2d_run/test_periodic_periodic.py
@@ -1,6 +1,5 @@
 from __future__ import division
 from builtins import range
-from past.utils import old_div
 import numpy as np
 import matplotlib.pyplot as plt
 import sys
@@ -55,7 +54,7 @@ def test():
     # Gaussian initial conditions
     W  = 200.e3                # Width
     amp = 1.                  # Amplitude
-    sim.soln.h[:,:,0] += amp*np.exp(-(old_div(sim.X,W))**2 - (old_div(sim.Y,W))**2)
+    sim.soln.h[:,:,0] += amp*np.exp(-(sim.X/W)**2 - (sim.Y/W)**2)
 
     # Run the simulation
     sim.run()

--- a/testing/test_does_2d_run/test_periodic_periodic.py
+++ b/testing/test_does_2d_run/test_periodic_periodic.py
@@ -6,7 +6,7 @@ import sys
 # At the moment it is given explicitely.
 # In the future, it could also be added to the
 # pythonpath environment variable
-sys.path.append('../src')
+sys.path.append('../../src')
 
 import Steppers as Step
 import Fluxes as Flux
@@ -20,27 +20,27 @@ def test():
     # Geometry and Model Equations
     sim.geomx       = 'periodic'
     sim.geomy       = 'periodic'
-    sim.stepper     = Step.AB3      
-    sim.method      = 'Spectral'    
-    sim.dynamics    = 'Nonlinear'  
-    sim.flux_method = Flux.spectral_sw 
+    sim.stepper     = Step.AB3
+    sim.method      = 'Spectral'
+    sim.dynamics    = 'Nonlinear'
+    sim.flux_method = Flux.spectral_sw
 
     # Specify paramters
-    sim.Lx  = 4000e3  
-    sim.Ly  = 4000e3   
-    sim.Nx  = 128       
-    sim.Ny  = 128      
-    sim.Nz  = 1         
-    sim.g   = 9.81       
-    sim.f0  = 1.e-4       
-    sim.beta = 0e-11       
-    sim.cfl = 0.1           
-    sim.Hs  = [100.]         
-    sim.rho = [1025.]         
-    sim.end_time = 5.*minute 
+    sim.Lx  = 4000e3
+    sim.Ly  = 4000e3
+    sim.Nx  = 128
+    sim.Ny  = 128
+    sim.Nz  = 1
+    sim.g   = 9.81
+    sim.f0  = 1.e-4
+    sim.beta = 0e-11
+    sim.cfl = 0.1
+    sim.Hs  = [100.]
+    sim.rho = [1025.]
+    sim.end_time = 5.*minute
 
-    sim.animate = 'None'    
-    sim.output = False       
+    sim.animate = 'None'
+    sim.output = False
     sim.diagnose = False
 
     # Initialize the grid and zero solutions
@@ -55,5 +55,4 @@ def test():
     sim.soln.h[:,:,0] += amp*np.exp(-(sim.X/W)**2 - (sim.Y/W)**2)
 
     # Run the simulation
-    sim.run() 
-
+    sim.run()

--- a/testing/test_does_2d_run/test_periodic_walls.py
+++ b/testing/test_does_2d_run/test_periodic_walls.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from builtins import range
+from past.utils import old_div
 import numpy as np
 import matplotlib.pyplot as plt
 import sys
@@ -52,7 +55,7 @@ def test():
     # Gaussian initial conditions
     W  = 200.e3                # Width
     amp = 1.                  # Amplitude
-    sim.soln.h[:,:,0] += amp*np.exp(-(sim.X/W)**2 - (sim.Y/W)**2)
+    sim.soln.h[:,:,0] += amp*np.exp(-(old_div(sim.X,W))**2 - (old_div(sim.Y,W))**2)
 
     # Run the simulation
     sim.run()

--- a/testing/test_does_2d_run/test_periodic_walls.py
+++ b/testing/test_does_2d_run/test_periodic_walls.py
@@ -1,6 +1,5 @@
 from __future__ import division
 from builtins import range
-from past.utils import old_div
 import numpy as np
 import matplotlib.pyplot as plt
 import sys
@@ -55,7 +54,7 @@ def test():
     # Gaussian initial conditions
     W  = 200.e3                # Width
     amp = 1.                  # Amplitude
-    sim.soln.h[:,:,0] += amp*np.exp(-(old_div(sim.X,W))**2 - (old_div(sim.Y,W))**2)
+    sim.soln.h[:,:,0] += amp*np.exp(-(sim.X/W)**2 - (sim.Y/W)**2)
 
     # Run the simulation
     sim.run()

--- a/testing/test_does_2d_run/test_periodic_walls.py
+++ b/testing/test_does_2d_run/test_periodic_walls.py
@@ -6,7 +6,7 @@ import sys
 # At the moment it is given explicitely.
 # In the future, it could also be added to the
 # pythonpath environment variable
-sys.path.append('../src')
+sys.path.append('../../src')
 
 import Steppers as Step
 import Fluxes as Flux
@@ -20,27 +20,27 @@ def test():
     # Geometry and Model Equations
     sim.geomx       = 'periodic'
     sim.geomy       = 'walls'
-    sim.stepper     = Step.AB3      
-    sim.method      = 'Spectral'    
-    sim.dynamics    = 'Nonlinear'  
-    sim.flux_method = Flux.spectral_sw 
+    sim.stepper     = Step.AB3
+    sim.method      = 'Spectral'
+    sim.dynamics    = 'Nonlinear'
+    sim.flux_method = Flux.spectral_sw
 
     # Specify paramters
-    sim.Lx  = 4000e3  
-    sim.Ly  = 4000e3   
-    sim.Nx  = 128       
-    sim.Ny  = 128      
-    sim.Nz  = 1         
-    sim.g   = 9.81       
-    sim.f0  = 1.e-4       
-    sim.beta = 0e-11       
-    sim.cfl = 0.1           
-    sim.Hs  = [100.]         
-    sim.rho = [1025.]         
-    sim.end_time = 5.*minute 
+    sim.Lx  = 4000e3
+    sim.Ly  = 4000e3
+    sim.Nx  = 128
+    sim.Ny  = 128
+    sim.Nz  = 1
+    sim.g   = 9.81
+    sim.f0  = 1.e-4
+    sim.beta = 0e-11
+    sim.cfl = 0.1
+    sim.Hs  = [100.]
+    sim.rho = [1025.]
+    sim.end_time = 5.*minute
 
-    sim.animate = 'None'    
-    sim.output = False       
+    sim.animate = 'None'
+    sim.output = False
     sim.diagnose = False
 
     # Initialize the grid and zero solutions
@@ -55,5 +55,4 @@ def test():
     sim.soln.h[:,:,0] += amp*np.exp(-(sim.X/W)**2 - (sim.Y/W)**2)
 
     # Run the simulation
-    sim.run() 
-
+    sim.run()

--- a/testing/test_does_2d_run/test_walls_periodic.py
+++ b/testing/test_does_2d_run/test_walls_periodic.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from builtins import range
+from past.utils import old_div
 import numpy as np
 import matplotlib.pyplot as plt
 import sys
@@ -52,7 +55,7 @@ def test():
     # Gaussian initial conditions
     W  = 200.e3                # Width
     amp = 1.                  # Amplitude
-    sim.soln.h[:,:,0] += amp*np.exp(-(sim.X/W)**2 - (sim.Y/W)**2)
+    sim.soln.h[:,:,0] += amp*np.exp(-(old_div(sim.X,W))**2 - (old_div(sim.Y,W))**2)
 
     # Run the simulation
     sim.run()

--- a/testing/test_does_2d_run/test_walls_periodic.py
+++ b/testing/test_does_2d_run/test_walls_periodic.py
@@ -6,7 +6,7 @@ import sys
 # At the moment it is given explicitely.
 # In the future, it could also be added to the
 # pythonpath environment variable
-sys.path.append('../src')
+sys.path.append('../../src')
 
 import Steppers as Step
 import Fluxes as Flux
@@ -20,27 +20,27 @@ def test():
     # Geometry and Model Equations
     sim.geomx       = 'walls'
     sim.geomy       = 'periodic'
-    sim.stepper     = Step.AB3      
-    sim.method      = 'Spectral'    
-    sim.dynamics    = 'Nonlinear'  
-    sim.flux_method = Flux.spectral_sw 
+    sim.stepper     = Step.AB3
+    sim.method      = 'Spectral'
+    sim.dynamics    = 'Nonlinear'
+    sim.flux_method = Flux.spectral_sw
 
     # Specify paramters
-    sim.Lx  = 4000e3  
-    sim.Ly  = 4000e3   
-    sim.Nx  = 128       
-    sim.Ny  = 128      
-    sim.Nz  = 1         
-    sim.g   = 9.81       
-    sim.f0  = 1.e-4       
-    sim.beta = 0e-11       
-    sim.cfl = 0.1           
-    sim.Hs  = [100.]         
-    sim.rho = [1025.]         
-    sim.end_time = 5.*minute 
+    sim.Lx  = 4000e3
+    sim.Ly  = 4000e3
+    sim.Nx  = 128
+    sim.Ny  = 128
+    sim.Nz  = 1
+    sim.g   = 9.81
+    sim.f0  = 1.e-4
+    sim.beta = 0e-11
+    sim.cfl = 0.1
+    sim.Hs  = [100.]
+    sim.rho = [1025.]
+    sim.end_time = 5.*minute
 
-    sim.animate = 'None'    
-    sim.output = False       
+    sim.animate = 'None'
+    sim.output = False
     sim.diagnose = False
 
     # Initialize the grid and zero solutions
@@ -55,4 +55,4 @@ def test():
     sim.soln.h[:,:,0] += amp*np.exp(-(sim.X/W)**2 - (sim.Y/W)**2)
 
     # Run the simulation
-    sim.run() 
+    sim.run()

--- a/testing/test_does_2d_run/test_walls_periodic.py
+++ b/testing/test_does_2d_run/test_walls_periodic.py
@@ -1,6 +1,5 @@
 from __future__ import division
 from builtins import range
-from past.utils import old_div
 import numpy as np
 import matplotlib.pyplot as plt
 import sys
@@ -55,7 +54,7 @@ def test():
     # Gaussian initial conditions
     W  = 200.e3                # Width
     amp = 1.                  # Amplitude
-    sim.soln.h[:,:,0] += amp*np.exp(-(old_div(sim.X,W))**2 - (old_div(sim.Y,W))**2)
+    sim.soln.h[:,:,0] += amp*np.exp(-(sim.X/W)**2 - (sim.Y/W)**2)
 
     # Run the simulation
     sim.run()

--- a/testing/test_does_2d_run/test_walls_walls.py
+++ b/testing/test_does_2d_run/test_walls_walls.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from builtins import range
+from past.utils import old_div
 import numpy as np
 import matplotlib.pyplot as plt
 import sys
@@ -52,7 +55,7 @@ def test():
     # Gaussian initial conditions
     W  = 200.e3                # Width
     amp = 1.                  # Amplitude
-    sim.soln.h[:,:,0] += amp*np.exp(-(sim.X/W)**2 - (sim.Y/W)**2)
+    sim.soln.h[:,:,0] += amp*np.exp(-(old_div(sim.X,W))**2 - (old_div(sim.Y,W))**2)
 
     # Run the simulation
     sim.run()

--- a/testing/test_does_2d_run/test_walls_walls.py
+++ b/testing/test_does_2d_run/test_walls_walls.py
@@ -1,6 +1,5 @@
 from __future__ import division
 from builtins import range
-from past.utils import old_div
 import numpy as np
 import matplotlib.pyplot as plt
 import sys
@@ -55,7 +54,7 @@ def test():
     # Gaussian initial conditions
     W  = 200.e3                # Width
     amp = 1.                  # Amplitude
-    sim.soln.h[:,:,0] += amp*np.exp(-(old_div(sim.X,W))**2 - (old_div(sim.Y,W))**2)
+    sim.soln.h[:,:,0] += amp*np.exp(-(sim.X/W)**2 - (sim.Y/W)**2)
 
     # Run the simulation
     sim.run()

--- a/testing/test_does_2d_run/test_walls_walls.py
+++ b/testing/test_does_2d_run/test_walls_walls.py
@@ -6,7 +6,7 @@ import sys
 # At the moment it is given explicitely.
 # In the future, it could also be added to the
 # pythonpath environment variable
-sys.path.append('../src')
+sys.path.append('../../src')
 
 import Steppers as Step
 import Fluxes as Flux
@@ -20,27 +20,27 @@ def test():
     # Geometry and Model Equations
     sim.geomx       = 'walls'
     sim.geomy       = 'walls'
-    sim.stepper     = Step.AB3      
-    sim.method      = 'Spectral'    
-    sim.dynamics    = 'Nonlinear'  
-    sim.flux_method = Flux.spectral_sw 
+    sim.stepper     = Step.AB3
+    sim.method      = 'Spectral'
+    sim.dynamics    = 'Nonlinear'
+    sim.flux_method = Flux.spectral_sw
 
     # Specify paramters
-    sim.Lx  = 4000e3  
-    sim.Ly  = 4000e3   
-    sim.Nx  = 128       
-    sim.Ny  = 128      
-    sim.Nz  = 1         
-    sim.g   = 9.81       
-    sim.f0  = 1.e-4       
-    sim.beta = 0e-11       
-    sim.cfl = 0.1           
-    sim.Hs  = [100.]         
-    sim.rho = [1025.]         
-    sim.end_time = 5.*minute 
+    sim.Lx  = 4000e3
+    sim.Ly  = 4000e3
+    sim.Nx  = 128
+    sim.Ny  = 128
+    sim.Nz  = 1
+    sim.g   = 9.81
+    sim.f0  = 1.e-4
+    sim.beta = 0e-11
+    sim.cfl = 0.1
+    sim.Hs  = [100.]
+    sim.rho = [1025.]
+    sim.end_time = 5.*minute
 
-    sim.animate = 'None'    
-    sim.output = False       
+    sim.animate = 'None'
+    sim.output = False
     sim.diagnose = False
 
     # Initialize the grid and zero solutions
@@ -55,5 +55,4 @@ def test():
     sim.soln.h[:,:,0] += amp*np.exp(-(sim.X/W)**2 - (sim.Y/W)**2)
 
     # Run the simulation
-    sim.run() 
-
+    sim.run()

--- a/testing/test_steppers/test_AB2.py
+++ b/testing/test_steppers/test_AB2.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from builtins import range
+from past.utils import old_div
 import numpy as np
 import matplotlib.pyplot as plt
 import sys
@@ -44,6 +47,6 @@ def test():
     x0 = 1.*sim.Lx/2.
     W  = 200.e3
     amp = 1.
-    sim.soln.h[:,:,0] += amp*np.exp(-(sim.Y)**2/(W**2))
+    sim.soln.h[:,:,0] += amp*np.exp(old_div(-(sim.Y)**2,(W**2)))
 
     sim.run()

--- a/testing/test_steppers/test_AB2.py
+++ b/testing/test_steppers/test_AB2.py
@@ -1,6 +1,5 @@
 from __future__ import division
 from builtins import range
-from past.utils import old_div
 import numpy as np
 import matplotlib.pyplot as plt
 import sys
@@ -47,6 +46,6 @@ def test():
     x0 = 1.*sim.Lx/2.
     W  = 200.e3
     amp = 1.
-    sim.soln.h[:,:,0] += amp*np.exp(old_div(-(sim.Y)**2,(W**2)))
+    sim.soln.h[:,:,0] += amp*np.exp(-(sim.Y)**2/(W**2))
 
     sim.run()

--- a/testing/test_steppers/test_AB2.py
+++ b/testing/test_steppers/test_AB2.py
@@ -2,7 +2,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 import sys
 
-sys.path.append('../src')
+sys.path.append('../../src')
 
 import Steppers as Step
 import Fluxes as Flux
@@ -12,39 +12,38 @@ from constants import minute, hour, day
 
 def test():
 
-    sim = Simulation() 
+    sim = Simulation()
 
     # Geometry and Model Equations
-    sim.geomy       = 'periodic'  
-    sim.stepper     = Step.AB2     
-    sim.method      = 'Spectral'     
-    sim.dynamics    = 'Nonlinear'     
-    sim.flux_method = Flux.spectral_sw 
+    sim.geomy       = 'periodic'
+    sim.stepper     = Step.AB2
+    sim.method      = 'Spectral'
+    sim.dynamics    = 'Nonlinear'
+    sim.flux_method = Flux.spectral_sw
 
     # Specify paramters
-    sim.Ly  = 4000e3   
-    sim.Ny  = 128       
-    sim.cfl = 0.5        
-    sim.Hs  = [100.]      
-    sim.rho = [1025.]      
+    sim.Ly  = 4000e3
+    sim.Ny  = 128
+    sim.cfl = 0.5
+    sim.Hs  = [100.]
+    sim.rho = [1025.]
     sim.end_time = 5.*minute
 
     # Plotting parameters
-    sim.animate = 'None'  
-    sim.output = False   
-    sim.diagnose = False 
+    sim.animate = 'None'
+    sim.output = False
+    sim.diagnose = False
 
     # Initialize the grid and zero solutions
     sim.initialize()
 
-    for ii in range(sim.Nz): 
+    for ii in range(sim.Nz):
         sim.soln.h[:,:,ii] = sim.Hs[ii]
 
     # Gaussian initial conditions
-    x0 = 1.*sim.Lx/2.     
-    W  = 200.e3          
-    amp = 1.            
+    x0 = 1.*sim.Lx/2.
+    W  = 200.e3
+    amp = 1.
     sim.soln.h[:,:,0] += amp*np.exp(-(sim.Y)**2/(W**2))
 
-    sim.run()      
-   
+    sim.run()

--- a/testing/test_steppers/test_AB3.py
+++ b/testing/test_steppers/test_AB3.py
@@ -2,7 +2,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 import sys
 
-sys.path.append('../src')
+sys.path.append('../../src')
 
 import Steppers as Step
 import Fluxes as Flux
@@ -12,39 +12,38 @@ from constants import minute, hour, day
 
 def test():
 
-    sim = Simulation() 
+    sim = Simulation()
 
     # Geometry and Model Equations
-    sim.geomy       = 'periodic'  
-    sim.stepper     = Step.AB3   
-    sim.method      = 'Spectral'     
-    sim.dynamics    = 'Nonlinear'     
-    sim.flux_method = Flux.spectral_sw 
+    sim.geomy       = 'periodic'
+    sim.stepper     = Step.AB3
+    sim.method      = 'Spectral'
+    sim.dynamics    = 'Nonlinear'
+    sim.flux_method = Flux.spectral_sw
 
     # Specify paramters
-    sim.Ly  = 4000e3   
-    sim.Ny  = 128       
-    sim.cfl = 0.5        
-    sim.Hs  = [100.]      
-    sim.rho = [1025.]      
+    sim.Ly  = 4000e3
+    sim.Ny  = 128
+    sim.cfl = 0.5
+    sim.Hs  = [100.]
+    sim.rho = [1025.]
     sim.end_time = 5.*minute
 
     # Plotting parameters
-    sim.animate = 'None'  
-    sim.output = False   
-    sim.diagnose = False 
+    sim.animate = 'None'
+    sim.output = False
+    sim.diagnose = False
 
     # Initialize the grid and zero solutions
     sim.initialize()
 
-    for ii in range(sim.Nz): 
+    for ii in range(sim.Nz):
         sim.soln.h[:,:,ii] = sim.Hs[ii]
 
     # Gaussian initial conditions
-    x0 = 1.*sim.Lx/2.     
-    W  = 200.e3          
-    amp = 1.            
+    x0 = 1.*sim.Lx/2.
+    W  = 200.e3
+    amp = 1.
     sim.soln.h[:,:,0] += amp*np.exp(-(sim.Y)**2/(W**2))
 
-    sim.run()      
-
+    sim.run()

--- a/testing/test_steppers/test_AB3.py
+++ b/testing/test_steppers/test_AB3.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from builtins import range
+from past.utils import old_div
 import numpy as np
 import matplotlib.pyplot as plt
 import sys
@@ -44,6 +47,6 @@ def test():
     x0 = 1.*sim.Lx/2.
     W  = 200.e3
     amp = 1.
-    sim.soln.h[:,:,0] += amp*np.exp(-(sim.Y)**2/(W**2))
+    sim.soln.h[:,:,0] += amp*np.exp(old_div(-(sim.Y)**2,(W**2)))
 
     sim.run()

--- a/testing/test_steppers/test_AB3.py
+++ b/testing/test_steppers/test_AB3.py
@@ -1,6 +1,5 @@
 from __future__ import division
 from builtins import range
-from past.utils import old_div
 import numpy as np
 import matplotlib.pyplot as plt
 import sys
@@ -47,6 +46,6 @@ def test():
     x0 = 1.*sim.Lx/2.
     W  = 200.e3
     amp = 1.
-    sim.soln.h[:,:,0] += amp*np.exp(old_div(-(sim.Y)**2,(W**2)))
+    sim.soln.h[:,:,0] += amp*np.exp(-(sim.Y)**2/(W**2))
 
     sim.run()

--- a/testing/test_steppers/test_Euler.py
+++ b/testing/test_steppers/test_Euler.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from builtins import range
+from past.utils import old_div
 import numpy as np
 import matplotlib.pyplot as plt
 import sys
@@ -44,6 +47,6 @@ def test():
     x0 = 1.*sim.Lx/2.
     W  = 200.e3
     amp = 1.
-    sim.soln.h[:,:,0] += amp*np.exp(-(sim.Y)**2/(W**2))
+    sim.soln.h[:,:,0] += amp*np.exp(old_div(-(sim.Y)**2,(W**2)))
 
     sim.run()

--- a/testing/test_steppers/test_Euler.py
+++ b/testing/test_steppers/test_Euler.py
@@ -2,7 +2,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 import sys
 
-sys.path.append('../src')
+sys.path.append('../../src')
 
 import Steppers as Step
 import Fluxes as Flux
@@ -12,39 +12,38 @@ from constants import minute, hour, day
 
 def test():
 
-    sim = Simulation() 
+    sim = Simulation()
 
     # Geometry and Model Equations
-    sim.geomy       = 'periodic'  
-    sim.stepper     = Step.Euler   
-    sim.method      = 'Spectral'     
-    sim.dynamics    = 'Nonlinear'     
-    sim.flux_method = Flux.spectral_sw 
+    sim.geomy       = 'periodic'
+    sim.stepper     = Step.Euler
+    sim.method      = 'Spectral'
+    sim.dynamics    = 'Nonlinear'
+    sim.flux_method = Flux.spectral_sw
 
     # Specify paramters
-    sim.Ly  = 4000e3   
-    sim.Ny  = 128       
-    sim.cfl = 0.5        
-    sim.Hs  = [100.]      
-    sim.rho = [1025.]      
+    sim.Ly  = 4000e3
+    sim.Ny  = 128
+    sim.cfl = 0.5
+    sim.Hs  = [100.]
+    sim.rho = [1025.]
     sim.end_time = 5.*minute
 
     # Plotting parameters
-    sim.animate = 'None'  
-    sim.output = False   
-    sim.diagnose = False 
+    sim.animate = 'None'
+    sim.output = False
+    sim.diagnose = False
 
     # Initialize the grid and zero solutions
     sim.initialize()
 
-    for ii in range(sim.Nz): 
+    for ii in range(sim.Nz):
         sim.soln.h[:,:,ii] = sim.Hs[ii]
 
     # Gaussian initial conditions
-    x0 = 1.*sim.Lx/2.     
-    W  = 200.e3          
-    amp = 1.            
+    x0 = 1.*sim.Lx/2.
+    W  = 200.e3
+    amp = 1.
     sim.soln.h[:,:,0] += amp*np.exp(-(sim.Y)**2/(W**2))
 
-    sim.run()      
-  
+    sim.run()

--- a/testing/test_steppers/test_Euler.py
+++ b/testing/test_steppers/test_Euler.py
@@ -1,6 +1,5 @@
 from __future__ import division
 from builtins import range
-from past.utils import old_div
 import numpy as np
 import matplotlib.pyplot as plt
 import sys
@@ -47,6 +46,6 @@ def test():
     x0 = 1.*sim.Lx/2.
     W  = 200.e3
     amp = 1.
-    sim.soln.h[:,:,0] += amp*np.exp(old_div(-(sim.Y)**2,(W**2)))
+    sim.soln.h[:,:,0] += amp*np.exp(-(sim.Y)**2/(W**2))
 
     sim.run()


### PR DESCRIPTION
I used the `futurize` tool to automatically convert all the python code to be Python 2/3 compatible.

This resulted in a lot of calls to `old_div()` which made the code hard to read, and were mostly unnecessary, because the vast majority of the division operations in the codebase are all floating point anyway. So I got rid of most of the `old_div()` calls.

The examples are now working in both Python 2.7 and Python 3.6 on my system.

This also includes the path fix for the test code I introduced in PR https://github.com/PyRsw/PyRsw/pull/23

This PR resolves issue https://github.com/PyRsw/PyRsw/issues/17